### PR TITLE
COOK-11 Use ssl.enabled for all SSL starting with CDAP 2.5

### DIFF
--- a/recipes/security_init.rb
+++ b/recipes/security_init.rb
@@ -21,7 +21,16 @@ include_recipe 'cdap::security'
 
 # Create a new keystore if SSL is enabled
 execute 'create-security-server-ssl-keystore' do
-  ssl_enabled = node['cdap']['cdap_site']['security.server.ssl.enabled'] || false
+  ssl_enabled =
+    if node['cdap']['version'].to_f < 2.5 && node['cdap'].key?('cdap_site') &&
+       node['cdap']['cdap_site'].key?('security.server.ssl.enabled')
+      node['cdap']['cdap_site']['security.server.ssl.enabled']
+    elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled')
+      node['cdap']['cdap_site']['ssl.enabled']
+    else
+      false
+    end
+
   password = node['cdap']['cdap_site']['security.server.ssl.keystore.password']
   path = node['cdap']['cdap_site']['security.server.ssl.keystore.path']
   common_name = node['cdap']['security']['ssl_common_name']

--- a/recipes/web_app_init.rb
+++ b/recipes/web_app_init.rb
@@ -23,7 +23,16 @@ include_recipe 'cdap::web_app'
 
 ### Generate a certificate if SSL is enabled
 execute 'generate-webapp-ssl-cert' do
-  ssl_enabled = node['cdap']['cdap_site']['ssl.enabled'] || false
+  ssl_enabled =
+    if node['cdap']['version'].to_f < 2.5 && node['cdap'].key?('cdap_site') &&
+       node['cdap']['cdap_site'].key?('security.server.ssl.enabled')
+      node['cdap']['cdap_site']['security.server.ssl.enabled']
+    elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled')
+      node['cdap']['cdap_site']['ssl.enabled']
+    else
+      false
+    end
+
   common_name = node['cdap']['security']['ssl_common_name']
   keypath = node['cdap']['cdap_site']['dashboard.ssl.key']
   certpath = node['cdap']['cdap_site']['dashboard.ssl.cert']


### PR DESCRIPTION
Starting with CDAP 2.5, the property name changed from `security.server.ssl.enabled` to just `ssl.enabled` to control all of the components.
