### PR TITLE
Update Travis configuration to use containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ rvm:
 cache: bundler
 sudo: false
 bundler_args: --jobs 7 --without docs integration
-install: bundle install
 script: bundle exec rake


### PR DESCRIPTION
Travis CI has a new container-based infrastructure which supports caching of dependency resources. Switch to use this new infrastructure and take advantage of the caching.
