### PR TITLE
Use cdap user on secure Hadoop clusters

### DIFF
--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -22,7 +22,7 @@ include_recipe 'cdap::default'
 # We also need the configuration, so we can run HDFS commands
 execute 'initaction-create-hdfs-cdap-dir' do
   not_if  "hdfs dfs -test -d #{node['cdap']['cdap_site']['hdfs.namespace']}", :user => 'hdfs'
-  command "hdfs dfs -mkdir -p #{node['cdap']['cdap_site']['hdfs.namespace']} && hdfs dfs -chown yarn #{node['cdap']['cdap_site']['hdfs.namespace']}"
+  command "hdfs dfs -mkdir -p #{node['cdap']['cdap_site']['hdfs.namespace']} && hdfs dfs -chown #{node['cdap']['cdap_site']['hdfs.user']} #{node['cdap']['cdap_site']['hdfs.namespace']}"
   timeout 300
   user 'hdfs'
   group 'hdfs'


### PR DESCRIPTION
This fixes a bug which always set `cdap['core_site']['hdfs.namespace']` owner to `yarn` and adds the `cdap` user to YARN's `container-executor.cfg` property `allowed.system.users`...

**NOTE:** to use the `cdap` user, the user must exist on every node in the cluster!

This is needed for caskdata/cdap#961 to be seamless in Coopr.