### PR TITLE
create hdfs /user/[cdap.user] directory

### DIFF
--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -27,3 +27,11 @@ execute 'initaction-create-hdfs-cdap-dir' do
   user 'hdfs'
   group 'hdfs'
 end
+
+execute 'initaction-create-hdfs-cdap-user-dir' do
+  not_if  "hdfs dfs -test -d /user/#{node['cdap']['cdap_site']['hdfs.user']}", :user => 'hdfs'
+  command "hdfs dfs -mkdir -p /user/#{node['cdap']['cdap_site']['hdfs.user']} && hdfs dfs -chown #{node['cdap']['cdap_site']['hdfs.user']} /user/#{node['cdap']['cdap_site']['hdfs.user']}"
+  timeout 300
+  user 'hdfs'
+  group 'hdfs'
+end


### PR DESCRIPTION
Creates the ``hdfs://user/[hdfs.user]`` directory in HDFS.  Per @ghelmling this is needed in some configurations and recommends to explicitly set our yarn.app.mapreduce.am.staging-dir to this dir in our templates.  See also https://issues.cask.co/browse/CDAP-1232?filter=10224