### PR TITLE
Test HDP 2.2 via Kitchen and add Ruby 2.1.4 to Travis CI

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -82,3 +82,10 @@ suites:
       - recipe[cdap::web_app_init]
       - recipe[minitest-handler::default]
     attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.1' } }
+  - name: hdp22
+    run_list:
+      - recipe[cdap::fullstack]
+      - recipe[cdap::security_init]
+      - recipe[cdap::web_app_init]
+      - recipe[minitest-handler::default]
+    attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.2' } }

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@
 language: ruby
 rvm:
   - 1.9.3
+  - 2.1.4
 cache: bundler
 sudo: false
 bundler_args: --jobs 7 --without docs integration


### PR DESCRIPTION
The Travis build below uses both Ruby versions, so that part is tested.