### PR TITLE
Test copying logback-container.xml

### DIFF
--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -20,18 +20,22 @@ describe 'cdap::config' do
       expect(chef_run).to run_execute('copy logback.xml from conf.dist')
     end
 
+    it 'does not run execute[copy logback-container.xml from conf.dist]' do
+      expect(chef_run).not_to run_execute('copy logback-container.xml from conf.dist')
+    end
+
     it 'runs execute[update cdap-conf alternatives]' do
       expect(chef_run).to run_execute('update cdap-conf alternatives')
     end
   end
 
-  context 'using cdap 2.7.0' do
+  context 'using cdap 2.8.0' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
         node.automatic['domain'] = 'example.com'
         node.default['hadoop']['hdfs_site']['dfs.datanode.max.transfer.threads'] = '4096'
         node.default['hadoop']['mapred_site']['mapreduce.framework.name'] = 'yarn'
-        node.override['cdap']['version'] = '2.7.0-1'
+        node.override['cdap']['version'] = '2.8.0-1'
         node.default['cdap']['cdap_env']['log_dir'] = '/test/logs/cdap'
         stub_command(/update-alternatives --display /).and_return(false)
         stub_command(/test -L /).and_return(false)
@@ -40,6 +44,10 @@ describe 'cdap::config' do
 
     it 'creates /etc/cdap/conf.chef/cdap-env.sh' do
       expect(chef_run).to create_template('/etc/cdap/conf.chef/cdap-env.sh')
+    end
+
+    it 'runs execute[copy logback-container.xml from conf.dist]' do
+      expect(chef_run).to run_execute('copy logback-container.xml from conf.dist')
     end
   end
 end


### PR DESCRIPTION
This commit changes the `2.7.0` test in config to `2.8.0` which future-proofs the testing against the upcoming CDAP 2.8 release.

```
Finished in 37.43 seconds (files took 3.88 seconds to load)
35 examples, 0 failures

ChefSpec Coverage report generated...

  Total Resources:   30
  Touched Resources: 30
  Touch Coverage:    100.0%

You are awesome and so is your test coverage! Have a fantastic day!
```