### PR TITLE
Do not manage /opt/cdap from cdap user

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,7 @@
 ---
 driver:
   name: vagrant
+  vm_hostname: test-kitchen.local
   customize:
     cpus: 2
     memory: 4096

--- a/recipes/sdk.rb
+++ b/recipes/sdk.rb
@@ -41,7 +41,6 @@ user node['cdap']['sdk']['user'] do
   comment 'CDAP SDK Service Account'
   home node['cdap']['sdk']['install_path']
   shell '/bin/bash'
-  supports :manage_home => true
   system true
   action :create
 end


### PR DESCRIPTION
Otherwise, the resource will fail if `/opt/cdap` exists for any reason, already.