### PR TITLE
add sdk restart if ark resource updates

### DIFF
--- a/recipes/sdk.rb
+++ b/recipes/sdk.rb
@@ -54,6 +54,7 @@ ark 'sdk' do
   version ver
   owner node['cdap']['sdk']['user']
   group node['cdap']['sdk']['user']
+  notifies :restart, 'service[cdap-sdk]', :delayed
 end
 
 template '/etc/init.d/cdap-sdk' do


### PR DESCRIPTION
adds a delayed notification to restart the SDK at the end of the chef run if the ark resource gets updated