### PR TITLE
Feature/cdap ui

### DIFF
--- a/files/default/tests/minitest/ui_test.rb
+++ b/files/default/tests/minitest/ui_test.rb
@@ -1,0 +1,11 @@
+require File.expand_path('../support/helpers', __FILE__)
+
+describe 'cdap::ui' do
+  include Helpers::CDAP
+
+  it 'verifies ui installation' do
+    package('cdap-ui').must_be_installed
+    file('/opt/cdap/ui/VERSION').must_exist.with(:owner, 'cdap').and(:group, 'cdap')
+    file('/etc/init.d/cdap-ui').must_exist.with(:owner, 'root').and(:group, 'root').and(:mode, '0755')
+  end
+end

--- a/recipes/fullstack.rb
+++ b/recipes/fullstack.rb
@@ -19,6 +19,8 @@
 
 include_recipe 'cdap::default'
 
-%w(cli gateway kafka master web_app).each do |recipe|
+ui_recipe = node['cdap']['version'].to_i < 3 ? 'web_app' : 'ui'
+
+%W(cli gateway kafka master #{ui_recipe}).each do |recipe|
   include_recipe "cdap::#{recipe}"
 end

--- a/recipes/ui.rb
+++ b/recipes/ui.rb
@@ -51,7 +51,7 @@ if node['cdap'].key?('ui')
   end # End /etc/default/cdap-ui
 end
 
-service 'cdap-web-app' do
-  status_command 'service cdap-web-app status'
+service 'cdap-ui' do
+  status_command 'service cdap-ui status'
   action :nothing
 end

--- a/recipes/ui.rb
+++ b/recipes/ui.rb
@@ -1,8 +1,8 @@
 #
 # Cookbook Name:: cdap
-# Recipe:: web_app
+# Recipe:: ui
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,13 +26,13 @@ end
 
 include_recipe 'cdap::repo'
 
-package 'cdap-web-app' do
+package 'cdap-ui' do
   action :install
   version node['cdap']['version']
 end
 
-if node['cdap'].key?('web_app')
-  my_vars = { :options => node['cdap']['web_app'] }
+if node['cdap'].key?('ui')
+  my_vars = { :options => node['cdap']['ui'] }
 
   directory '/etc/default' do
     owner 'root'
@@ -41,14 +41,14 @@ if node['cdap'].key?('web_app')
     action :create
   end
 
-  template '/etc/default/cdap-web-app' do
+  template '/etc/default/cdap-ui' do
     source 'generic-env.sh.erb'
     mode '0755'
     owner 'root'
     group 'root'
     action :create
     variables my_vars
-  end # End /etc/default/cdap-web-app
+  end # End /etc/default/cdap-ui
 end
 
 service 'cdap-web-app' do

--- a/recipes/ui.rb
+++ b/recipes/ui.rb
@@ -1,0 +1,57 @@
+#
+# Cookbook Name:: cdap
+# Recipe:: web_app
+#
+# Copyright © 2013-2014 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'nodejs::default'
+link '/usr/bin/node' do
+  to '/usr/local/bin/node'
+  action :create
+  not_if 'test -e /usr/bin/node'
+end
+
+include_recipe 'cdap::repo'
+
+package 'cdap-web-app' do
+  action :install
+  version node['cdap']['version']
+end
+
+if node['cdap'].key?('web_app')
+  my_vars = { :options => node['cdap']['web_app'] }
+
+  directory '/etc/default' do
+    owner 'root'
+    group 'root'
+    mode '0755'
+    action :create
+  end
+
+  template '/etc/default/cdap-web-app' do
+    source 'generic-env.sh.erb'
+    mode '0755'
+    owner 'root'
+    group 'root'
+    action :create
+    variables my_vars
+  end # End /etc/default/cdap-web-app
+end
+
+service 'cdap-web-app' do
+  status_command 'service cdap-web-app status'
+  action :nothing
+end

--- a/recipes/ui_init.rb
+++ b/recipes/ui_init.rb
@@ -1,0 +1,42 @@
+#
+# Cookbook Name:: cdap
+# Recipe:: web_app_init
+#
+# Copyright © 2013-2014 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Dependencies
+# Need to make sure certpath and keypath attributes are set
+
+include_recipe 'cdap::web_app'
+
+### Generate a certificate if SSL is enabled
+execute 'generate-webapp-ssl-cert' do
+  ssl_enabled =
+    if node['cdap']['version'].to_f < 2.5 && node['cdap'].key?('cdap_site') &&
+       node['cdap']['cdap_site'].key?('security.server.ssl.enabled')
+      node['cdap']['cdap_site']['security.server.ssl.enabled']
+    elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled')
+      node['cdap']['cdap_site']['ssl.enabled']
+    else
+      false
+    end
+
+  common_name = node['cdap']['security']['ssl_common_name']
+  keypath = node['cdap']['cdap_site']['dashboard.ssl.key']
+  certpath = node['cdap']['cdap_site']['dashboard.ssl.cert']
+  command "openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout #{keypath} -out #{certpath} -subj '/C=US/ST=CA/L=Palo Alto/OU=cdap/O=cdap/CN=#{common_name}'"
+  not_if { File.exist?(certpath) && File.exist?(keypath) }
+  only_if { ssl_enabled }
+end

--- a/recipes/ui_init.rb
+++ b/recipes/ui_init.rb
@@ -1,8 +1,8 @@
 #
 # Cookbook Name:: cdap
-# Recipe:: web_app_init
+# Recipe:: ui_init
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,10 +19,10 @@
 # Dependencies
 # Need to make sure certpath and keypath attributes are set
 
-include_recipe 'cdap::web_app'
+include_recipe 'cdap::ui'
 
 ### Generate a certificate if SSL is enabled
-execute 'generate-webapp-ssl-cert' do
+execute 'generate-ui-ssl-cert' do
   ssl_enabled =
     if node['cdap']['version'].to_f < 2.5 && node['cdap'].key?('cdap_site') &&
        node['cdap']['cdap_site'].key?('security.server.ssl.enabled')

--- a/recipes/web_app.rb
+++ b/recipes/web_app.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: web_app
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,41 +17,46 @@
 # limitations under the License.
 #
 
-include_recipe 'nodejs::default'
-link '/usr/bin/node' do
-  to '/usr/local/bin/node'
-  action :create
-  not_if 'test -e /usr/bin/node'
-end
-
-include_recipe 'cdap::repo'
-
-package 'cdap-web-app' do
-  action :install
-  version node['cdap']['version']
-end
-
-if node['cdap'].key?('web_app')
-  my_vars = { :options => node['cdap']['web_app'] }
-
-  directory '/etc/default' do
-    owner 'root'
-    group 'root'
-    mode '0755'
+# web_app is deprecated in favor of ui in CDAP 3.0
+if node['cdap']['version'].to_i > 2
+  include_recipe 'cdap::ui'
+else
+  include_recipe 'nodejs::default'
+  link '/usr/bin/node' do
+    to '/usr/local/bin/node'
     action :create
+    not_if 'test -e /usr/bin/node'
   end
 
-  template '/etc/default/cdap-web-app' do
-    source 'generic-env.sh.erb'
-    mode '0755'
-    owner 'root'
-    group 'root'
-    action :create
-    variables my_vars
-  end # End /etc/default/cdap-web-app
-end
+  include_recipe 'cdap::repo'
 
-service 'cdap-web-app' do
-  status_command 'service cdap-web-app status'
-  action :nothing
+  package 'cdap-web-app' do
+    action :install
+    version node['cdap']['version']
+  end
+
+  if node['cdap'].key?('web_app')
+    my_vars = { :options => node['cdap']['web_app'] }
+
+    directory '/etc/default' do
+      owner 'root'
+      group 'root'
+      mode '0755'
+      action :create
+    end
+
+    template '/etc/default/cdap-web-app' do
+      source 'generic-env.sh.erb'
+      mode '0755'
+      owner 'root'
+      group 'root'
+      action :create
+      variables my_vars
+    end # End /etc/default/cdap-web-app
+  end
+
+  service 'cdap-web-app' do
+    status_command 'service cdap-web-app status'
+    action :nothing
+  end
 end

--- a/recipes/web_app_init.rb
+++ b/recipes/web_app_init.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: web_app_init
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,24 +19,29 @@
 # Dependencies
 # Need to make sure certpath and keypath attributes are set
 
-include_recipe 'cdap::web_app'
+# web_app is deprecated in favor of ui in CDAP 3.0
+if node['cdap']['version'].to_i > 2
+  include_recipe 'cdap::ui'
+else
+  include_recipe 'cdap::web_app'
 
-### Generate a certificate if SSL is enabled
-execute 'generate-webapp-ssl-cert' do
-  ssl_enabled =
-    if node['cdap']['version'].to_f < 2.5 && node['cdap'].key?('cdap_site') &&
-       node['cdap']['cdap_site'].key?('security.server.ssl.enabled')
-      node['cdap']['cdap_site']['security.server.ssl.enabled']
-    elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled')
-      node['cdap']['cdap_site']['ssl.enabled']
-    else
-      false
-    end
+  ### Generate a certificate if SSL is enabled
+  execute 'generate-webapp-ssl-cert' do
+    ssl_enabled =
+      if node['cdap']['version'].to_f < 2.5 && node['cdap'].key?('cdap_site') &&
+         node['cdap']['cdap_site'].key?('security.server.ssl.enabled')
+        node['cdap']['cdap_site']['security.server.ssl.enabled']
+      elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled')
+        node['cdap']['cdap_site']['ssl.enabled']
+      else
+        false
+      end
 
-  common_name = node['cdap']['security']['ssl_common_name']
-  keypath = node['cdap']['cdap_site']['dashboard.ssl.key']
-  certpath = node['cdap']['cdap_site']['dashboard.ssl.cert']
-  command "openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout #{keypath} -out #{certpath} -subj '/C=US/ST=CA/L=Palo Alto/OU=cdap/O=cdap/CN=#{common_name}'"
-  not_if { File.exist?(certpath) && File.exist?(keypath) }
-  only_if { ssl_enabled }
+    common_name = node['cdap']['security']['ssl_common_name']
+    keypath = node['cdap']['cdap_site']['dashboard.ssl.key']
+    certpath = node['cdap']['cdap_site']['dashboard.ssl.cert']
+    command "openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout #{keypath} -out #{certpath} -subj '/C=US/ST=CA/L=Palo Alto/OU=cdap/O=cdap/CN=#{common_name}'"
+    not_if { File.exist?(certpath) && File.exist?(keypath) }
+    only_if { ssl_enabled }
+  end
 end

--- a/spec/ui_init_spec.rb
+++ b/spec/ui_init_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'cdap::ui_init' do
+  context 'on Centos 6.5 x86_64' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
+        node.automatic['domain'] = 'example.com'
+        stub_command('test -e /usr/bin/node').and_return(true)
+      end.converge(described_recipe)
+    end
+
+    it 'does not run execute[generate-ui-ssl-cert]' do
+      expect(chef_run).not_to run_execute('generate-ui-ssl-cert')
+    end
+  end
+
+  context 'with SSL' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
+        node.override['cdap']['cdap_site']['ssl.enabled'] = true
+        stub_command('test -e /usr/bin/node').and_return(true)
+      end.converge(described_recipe)
+    end
+
+    it 'executes generate-ui-ssl-cert' do
+      expect(chef_run).to run_execute('generate-ui-ssl-cert')
+    end
+  end
+end

--- a/spec/ui_spec.rb
+++ b/spec/ui_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe 'cdap::ui' do
+  context 'on Centos 6.5 x86_64' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
+        node.automatic['domain'] = 'example.com'
+        node.default['hadoop']['hdfs_site']['dfs.datanode.max.transfer.threads'] = '4096'
+        node.default['hadoop']['mapred_site']['mapreduce.framework.name'] = 'yarn'
+        stub_command('update-alternatives --display cdap-conf | grep best | awk \'{print $5}\' | grep /etc/cdap/conf.chef').and_return(false)
+        stub_command('update-alternatives --display hadoop-conf | grep best | awk \'{print $5}\' | grep /etc/hadoop/conf.chef').and_return(false)
+        stub_command('update-alternatives --display hbase-conf | grep best | awk \'{print $5}\' | grep /etc/hbase/conf.chef').and_return(false)
+        stub_command('update-alternatives --display hive-conf | grep best | awk \'{print $5}\' | grep /etc/hive/conf.chef').and_return(false)
+        stub_command('test -e /usr/bin/node').and_return(true)
+      end.converge(described_recipe)
+    end
+
+    it 'installs cdap-ui package' do
+      expect(chef_run).to install_package('cdap-ui')
+    end
+
+    it 'creates cdap-ui service, but does not run it' do
+      expect(chef_run).not_to start_service('cdap-ui')
+    end
+
+    it 'does not create /usr/bin/node link' do
+      expect(chef_run).not_to create_link('/usr/bin/node').with(
+        to: '/usr/local/bin/node'
+      )
+    end
+  end
+  context 'using older nodejs cookbook' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.4) do |node|
+        node.automatic['domain'] = 'example.com'
+        node.default['cdap']['repo']['url'] = 'https://USER:PASS@cdap.repo/path/to/repo'
+        node.default['hadoop']['hdfs_site']['dfs.datanode.max.transfer.threads'] = '4096'
+        node.default['hadoop']['mapred_site']['mapreduce.framework.name'] = 'yarn'
+        stub_command('update-alternatives --display cdap-conf | grep best | awk \'{print $5}\' | grep /etc/cdap/conf.chef').and_return(false)
+        stub_command('update-alternatives --display hadoop-conf | grep best | awk \'{print $5}\' | grep /etc/hadoop/conf.chef').and_return(false)
+        stub_command('update-alternatives --display hbase-conf | grep best | awk \'{print $5}\' | grep /etc/hbase/conf.chef').and_return(false)
+        stub_command('update-alternatives --display hive-conf | grep best | awk \'{print $5}\' | grep /etc/hive/conf.chef').and_return(false)
+        stub_command('test -e /usr/bin/node').and_return(false)
+      end.converge(described_recipe)
+    end
+
+    it 'creates /usr/bin/node link' do
+      expect(chef_run).to create_link('/usr/bin/node').with(
+        to: '/usr/local/bin/node'
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR updates the cookbook to handle the upcoming cdap-ui component in 3.0.  It triggers the new UI if ``[cdap][version]`` is 3 or greater.  the default ``[cdap][version]`` remains 2.8.0-1
- [x] ``ui.rb`` and ``ui_init.rb`` recipes, essentially cloned from the ``web_app`` counterparts
- [x] tests for above, also essentially cloned
- [x] hook in ``fullstack.rb`` to check the version and include ``web_app`` or ``ui`` appropriately
- [x] hook in the ``web_app`` recipes to check the version and defer to ``ui`` recipes instead if appropriate (for existing use-cases where ``web_app`` is in the runlist directly