### PR TITLE
Use our own init scripts

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -60,31 +60,31 @@ suites:
       - recipe[cdap::fullstack]
       - recipe[cdap::security_init]
       - recipe[cdap::web_app_init]
-    attributes: { hadoop: { distribution: 'cdh', distribution_version: 4 } }
+    attributes: { hadoop: { distribution: 'cdh', distribution_version: '4.7.1' } }
   - name: cdh5
     run_list:
       - recipe[cdap::fullstack]
       - recipe[cdap::security_init]
       - recipe[cdap::web_app_init]
-    attributes: { hadoop: { distribution: 'cdh', distribution_version: 5 } }
+    attributes: { hadoop: { distribution: 'cdh', distribution_version: '5.4.1' } }
   - name: hdp20
     run_list:
       - recipe[cdap::fullstack]
       - recipe[cdap::security_init]
       - recipe[cdap::web_app_init]
-    attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.0' } }
+    attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.0.11.0' } }
   - name: hdp21
     run_list:
       - recipe[cdap::fullstack]
       - recipe[cdap::security_init]
       - recipe[cdap::web_app_init]
-    attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.1' } }
+    attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.1.10.0' } }
   - name: hdp22
     run_list:
       - recipe[cdap::fullstack]
       - recipe[cdap::security_init]
       - recipe[cdap::web_app_init]
-    attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.2' } }
+    attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.2.4.2' } }
   - name: sdk
     run_list:
       - recipe[cdap::sdk]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,6 +9,22 @@ driver:
 provisioner:
   name: chef_solo
   require_chef_omnibus: true
+  attributes:
+    cdap:
+      gateway:
+        init_actions: 'start'
+      kafka:
+        init_actions: 'start'
+      master:
+        init_actions: 'start'
+      router:
+        init_actions: 'start'
+      security:
+        init_actions: 'start'
+      ui:
+        init_actions: 'start'
+      web_app:
+        init_actions: 'start'
 
 platforms:
   - name: centos-6.6
@@ -57,33 +73,33 @@ platforms:
 suites:
   - name: cdh4
     run_list:
-      - recipe[cdap::fullstack]
       - recipe[cdap::security_init]
       - recipe[cdap::web_app_init]
+      - recipe[cdap::fullstack]
     attributes: { hadoop: { distribution: 'cdh', distribution_version: '4.7.1' } }
   - name: cdh5
     run_list:
-      - recipe[cdap::fullstack]
       - recipe[cdap::security_init]
       - recipe[cdap::web_app_init]
+      - recipe[cdap::fullstack]
     attributes: { hadoop: { distribution: 'cdh', distribution_version: '5.4.1' } }
   - name: hdp20
     run_list:
-      - recipe[cdap::fullstack]
       - recipe[cdap::security_init]
       - recipe[cdap::web_app_init]
+      - recipe[cdap::fullstack]
     attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.0.11.0' } }
   - name: hdp21
     run_list:
-      - recipe[cdap::fullstack]
       - recipe[cdap::security_init]
       - recipe[cdap::web_app_init]
+      - recipe[cdap::fullstack]
     attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.1.10.0' } }
   - name: hdp22
     run_list:
-      - recipe[cdap::fullstack]
       - recipe[cdap::security_init]
       - recipe[cdap::web_app_init]
+      - recipe[cdap::fullstack]
     attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.2.4.2' } }
   - name: sdk
     run_list:

--- a/attributes/services.rb
+++ b/attributes/services.rb
@@ -1,0 +1,67 @@
+#
+# Cookbook Name:: cdap
+# Attribute:: services
+#
+# Copyright © 2015 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name = 'gateway'
+default['cdap'][name]['user'] = 'cdap'
+default['cdap'][name]['init_name'] = name.split.map(&:capitalize).join(' ')
+default['cdap'][name]['init_krb5'] = false
+default['cdap'][name]['init_cmd'] = "/opt/cdap/#{name}/bin/svc-#{name}"
+default['cdap'][name]['init_actions'] = [:nothing]
+
+name = 'kafka'
+default['cdap'][name]['user'] = 'cdap'
+default['cdap'][name]['init_name'] = 'Kafka Server'
+default['cdap'][name]['init_krb5'] = false
+default['cdap'][name]['init_cmd'] = "/opt/cdap/#{name}/bin/svc-#{name}-server"
+default['cdap'][name]['init_actions'] = [:nothing]
+
+name = 'master'
+default['cdap'][name]['user'] = 'cdap'
+default['cdap'][name]['init_name'] = name.split.map(&:capitalize).join(' ')
+default['cdap'][name]['init_krb5'] = true
+default['cdap'][name]['init_cmd'] = "/opt/cdap/#{name}/bin/svc-#{name}"
+default['cdap'][name]['init_actions'] = [:nothing]
+
+name = 'router'
+default['cdap'][name]['user'] = 'cdap'
+default['cdap'][name]['init_name'] = name.split.map(&:capitalize).join(' ')
+default['cdap'][name]['init_krb5'] = false
+default['cdap'][name]['init_cmd'] = "/opt/cdap/gateway/bin/svc-#{name}"
+default['cdap'][name]['init_actions'] = [:nothing]
+
+name = 'security'
+default['cdap'][name]['user'] = 'cdap'
+default['cdap'][name]['init_name'] = 'Auth Server'
+default['cdap'][name]['init_krb5'] = false
+default['cdap'][name]['init_cmd'] = "/opt/cdap/#{name}/bin/svc-auth-server"
+default['cdap'][name]['init_actions'] = [:nothing]
+
+name = 'ui'
+default['cdap'][name]['user'] = 'cdap'
+default['cdap'][name]['init_name'] = name.upcase
+default['cdap'][name]['init_krb5'] = false
+default['cdap'][name]['init_cmd'] = "/opt/cdap/#{name}/bin/svc-#{name}"
+default['cdap'][name]['init_actions'] = [:nothing]
+
+name = 'web_app'
+default['cdap'][name]['user'] = 'cdap'
+default['cdap'][name]['init_name'] = name.split('_').map(&:capitalize).join(' ')
+default['cdap'][name]['init_krb5'] = false
+default['cdap'][name]['init_cmd'] = "/opt/cdap/#{name}/bin/svc-#{name.gsub('_', '-')}"
+default['cdap'][name]['init_actions'] = [:nothing]

--- a/recipes/gateway.rb
+++ b/recipes/gateway.rb
@@ -32,8 +32,18 @@ unless node['cdap']['version'].to_f >= 2.6
 end
 
 svcs.each do |svc|
+  attrib = svc.gsub('cdap-', '').gsub('-', '_')
+  template "/etc/init.d/#{svc}" do
+    source 'cdap-service.erb'
+    mode 0755
+    owner 'root'
+    group 'root'
+    action :create
+    variables node['cdap'][attrib]
+  end
+
   service svc do
     status_command "service #{svc} status"
-    action :nothing
+    action node['cdap'][attrib]['init_actions']
   end
 end

--- a/recipes/kafka.rb
+++ b/recipes/kafka.rb
@@ -41,7 +41,16 @@ directory kafka_log_dir do
   recursive true
 end
 
+template '/etc/init.d/cdap-kafka-server' do
+  source 'cdap-service.erb'
+  mode 0755
+  owner 'root'
+  group 'root'
+  action :create
+  variables node['cdap']['kafka']
+end
+
 service 'cdap-kafka-server' do
   status_command 'service cdap-kafka-server status'
-  action :nothing
+  action node['cdap']['kafka']['init_actions']
 end

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -101,7 +101,16 @@ if node['hadoop'].key?('core_site') && node['hadoop']['core_site'].key?('hadoop.
   end
 end
 
+template '/etc/init.d/cdap-master' do
+  source 'cdap-service.erb'
+  mode 0755
+  owner 'root'
+  group 'root'
+  action :create
+  variables node['cdap']['master']
+end
+
 service 'cdap-master' do
   status_command 'service cdap-master status'
-  action :nothing
+  action node['cdap']['master']['init_actions']
 end

--- a/recipes/security.rb
+++ b/recipes/security.rb
@@ -25,7 +25,16 @@ package 'cdap-security' do
   version node['cdap']['version']
 end
 
+template '/etc/init.d/cdap-auth-server' do
+  source 'cdap-service.erb'
+  mode 0755
+  owner 'root'
+  group 'root'
+  action :create
+  variables node['cdap']['security']
+end
+
 service 'cdap-auth-server' do
   status_command 'service cdap-auth-server status'
-  action :nothing
+  action node['cdap']['security']['init_actions']
 end

--- a/recipes/ui.rb
+++ b/recipes/ui.rb
@@ -51,7 +51,16 @@ if node['cdap'].key?('ui')
   end # End /etc/default/cdap-ui
 end
 
+template '/etc/init.d/cdap-ui' do
+  source 'cdap-service.erb'
+  mode 0755
+  owner 'root'
+  group 'root'
+  action :create
+  variables node['cdap']['ui']
+end
+
 service 'cdap-ui' do
   status_command 'service cdap-ui status'
-  action :nothing
+  action node['cdap']['ui']['init_actions']
 end

--- a/recipes/web_app.rb
+++ b/recipes/web_app.rb
@@ -55,8 +55,17 @@ else
     end # End /etc/default/cdap-web-app
   end
 
+  template '/etc/init.d/cdap-web-app' do
+    source 'cdap-service.erb'
+    mode 0755
+    owner 'root'
+    group 'root'
+    action :create
+    variables node['cdap']['web_app']
+  end
+
   service 'cdap-web-app' do
     status_command 'service cdap-web-app status'
-    action :nothing
+    action node['cdap']['web_app']['init_actions']
   end
 end

--- a/spec/gateway_spec.rb
+++ b/spec/gateway_spec.rb
@@ -11,13 +11,22 @@ describe 'cdap::gateway' do
         stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'cdap-router'
+
+    %W(
+      /etc/init.d/#{pkg}
+    ).each do |file|
+      it "creates #{file} from template" do
+        expect(chef_run).to create_template(file)
+      end
+    end
 
     it 'installs cdap-gateway package' do
       expect(chef_run).to install_package('cdap-gateway')
     end
 
-    it 'creates cdap-router service, but does not run it' do
-      expect(chef_run).not_to start_service('cdap-router')
+    it "creates #{pkg} service, but does not run it" do
+      expect(chef_run).not_to start_service(pkg)
     end
   end
 
@@ -32,9 +41,18 @@ describe 'cdap::gateway' do
         stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'cdap-gateway'
 
-    it 'creates cdap-gateway service, but does not run it' do
-      expect(chef_run).not_to start_service('cdap-gateway')
+    %W(
+      /etc/init.d/#{pkg}
+    ).each do |file|
+      it "creates #{file} from template" do
+        expect(chef_run).to create_template(file)
+      end
+    end
+
+    it "creates #{pkg} service, but does not run it" do
+      expect(chef_run).not_to start_service(pkg)
     end
   end
 end

--- a/spec/kafka_spec.rb
+++ b/spec/kafka_spec.rb
@@ -11,6 +11,15 @@ describe 'cdap::kafka' do
         stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'cdap-kafka-server'
+
+    %W(
+      /etc/init.d/#{pkg}
+    ).each do |file|
+      it "creates #{file} from template" do
+        expect(chef_run).to create_template(file)
+      end
+    end
 
     it 'installs cdap-kafka package' do
       expect(chef_run).to install_package('cdap-kafka')
@@ -20,8 +29,8 @@ describe 'cdap::kafka' do
       expect(chef_run).to create_directory('/data/cdap/kafka-logs')
     end
 
-    it 'creates cdap-kafka-server service, but does not run it' do
-      expect(chef_run).not_to start_service('cdap-kafka-server')
+    it "creates #{pkg} service, but does not run it" do
+      expect(chef_run).not_to start_service(pkg)
     end
   end
 end

--- a/spec/master_spec.rb
+++ b/spec/master_spec.rb
@@ -11,19 +11,28 @@ describe 'cdap::master' do
         stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'cdap-master'
 
-    %w(cdap-hbase-compat-0.94 cdap-hbase-compat-0.96 cdap-hbase-compat-0.98).each do |pkg|
-      it "installs #{pkg} package" do
-        expect(chef_run).to install_package(pkg)
+    %w(cdap-hbase-compat-0.94 cdap-hbase-compat-0.96 cdap-hbase-compat-0.98).each do |compat|
+      it "installs #{compat} package" do
+        expect(chef_run).to install_package(compat)
       end
     end
 
-    it 'installs cdap-master package' do
-      expect(chef_run).to install_package('cdap-master')
+    %W(
+      /etc/init.d/#{pkg}
+    ).each do |file|
+      it "creates #{file} from template" do
+        expect(chef_run).to create_template(file)
+      end
     end
 
-    it 'creates cdap-master service, but does not run it' do
-      expect(chef_run).not_to start_service('cdap-master')
+    it "installs #{pkg} package" do
+      expect(chef_run).to install_package(pkg)
+    end
+
+    it "creates #{pkg} service, but does not run it" do
+      expect(chef_run).not_to start_service(pkg)
     end
   end
 

--- a/spec/security_spec.rb
+++ b/spec/security_spec.rb
@@ -8,13 +8,22 @@ describe 'cdap::security' do
         stub_command(/update-alternatives --display /).and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'cdap-auth-server'
+
+    %W(
+      /etc/init.d/#{pkg}
+    ).each do |file|
+      it "creates #{file} from template" do
+        expect(chef_run).to create_template(file)
+      end
+    end
 
     it 'installs cdap-security package' do
       expect(chef_run).to install_package('cdap-security')
     end
 
-    it 'creates cdap-auth-server service, but does not run it' do
-      expect(chef_run).not_to start_service('cdap-auth-server')
+    it "creates #{pkg} service, but does not run it" do
+      expect(chef_run).not_to start_service(pkg)
     end
   end
 end

--- a/spec/ui_spec.rb
+++ b/spec/ui_spec.rb
@@ -11,13 +11,22 @@ describe 'cdap::ui' do
         stub_command('test -e /usr/bin/node').and_return(true)
       end.converge(described_recipe)
     end
+    pkg = 'cdap-ui'
 
-    it 'installs cdap-ui package' do
-      expect(chef_run).to install_package('cdap-ui')
+    it "installs #{pkg} package" do
+      expect(chef_run).to install_package(pkg)
     end
 
-    it 'creates cdap-ui service, but does not run it' do
-      expect(chef_run).not_to start_service('cdap-ui')
+    %W(
+      /etc/init.d/#{pkg}
+    ).each do |file|
+      it "creates #{file} from template" do
+        expect(chef_run).to create_template(file)
+      end
+    end
+
+    it "creates #{pkg} service, but does not run it" do
+      expect(chef_run).not_to start_service(pkg)
     end
 
     it 'does not create /usr/bin/node link' do

--- a/spec/web_app_spec.rb
+++ b/spec/web_app_spec.rb
@@ -28,13 +28,22 @@ describe 'cdap::web_app' do
         stub_command(/update-alternatives --display /).and_return(false)
       end.converge(described_recipe)
     end
+    pkg = 'cdap-web-app'
 
-    it 'installs cdap-web-app package' do
-      expect(chef_run).to install_package('cdap-web-app')
+    it "installs #{pkg} package" do
+      expect(chef_run).to install_package(pkg)
     end
 
-    it 'creates cdap-web-app service, but does not run it' do
-      expect(chef_run).not_to start_service('cdap-web-app')
+    %W(
+      /etc/init.d/#{pkg}
+    ).each do |file|
+      it "creates #{file} from template" do
+        expect(chef_run).to create_template(file)
+      end
+    end
+
+    it "creates #{pkg} service, but does not run it" do
+      expect(chef_run).not_to start_service(pkg)
     end
 
     it 'does not create /usr/bin/node link' do

--- a/templates/default/cdap-service.erb
+++ b/templates/default/cdap-service.erb
@@ -20,7 +20,7 @@
 # description: Starts and stops the <%= @init_name %> service
 # 
 ### BEGIN INIT INFO
-# Provides:          cdap-<%= @init_name.downcase %>
+# Provides:          cdap-<%= @init_name.downcase.gsub(' ', '-') %>
 # Short-Description: Cask CDAP <%= @init_name %>
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
@@ -33,8 +33,13 @@
 SVC_COMMAND="<%= @init_cmd %> $*"
 
 # source configuration, if it exists
-if [[ -r /etc/default/cdap-<%= @init_name.downcase %> ]]; then
-  . /etc/default/cdap-<%= @init_name.downcase %>
+if [[ -r /etc/default/cdap-<%= @init_name.downcase.gsub(' ', '-') %> ]]; then
+  . /etc/default/cdap-<%= @init_name.downcase.gsub(' ', '-') %>
+fi
+
+# how about jdk.sh
+if [[ -r /etc/profile.d/jdk.sh ]]; then
+  . /etc/profile.d/jdk.sh
 fi
 
 <% if @init_krb5.to_s == 'true' %>


### PR DESCRIPTION
This replaces the init scripts shipped with CDAP with our own. These scripts are based on the original scripts, but only do kerberos configuration when configured. They, also, will source the Chef-delivered `/etc/profile.d/jdk.sh` to set `JAVA_HOME` for the services.