### PR TITLE
Update cdap-hbase-compat requirements

### DIFF
--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -19,9 +19,12 @@
 
 include_recipe 'cdap::default'
 
-pkgs = %w(cdap-hbase-compat-0.94 cdap-hbase-compat-0.96)
-if node['cdap']['version'].to_f >= 2.6 || node['cdap']['version'].split('.')[2].to_i >= 9000
+pkgs = ['cdap-hbase-compat-0.96']
+if node['cdap']['version'].to_f >= 2.6
   pkgs += ['cdap-hbase-compat-0.98']
+end
+if node['cdap']['version'].to_f < 3.1
+  pkgs += ['cdap-hbase-compat-0.94']
 end
 
 pkgs.each do |pkg|

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -19,13 +19,10 @@
 
 include_recipe 'cdap::default'
 
+# All released versions support HBase 0.96
 pkgs = ['cdap-hbase-compat-0.96']
-if node['cdap']['version'].to_f >= 2.6
-  pkgs += ['cdap-hbase-compat-0.98']
-end
-if node['cdap']['version'].to_f < 3.1
-  pkgs += ['cdap-hbase-compat-0.94']
-end
+pkgs += ['cdap-hbase-compat-0.98'] if node['cdap']['version'].to_f >= 2.6
+pkgs += ['cdap-hbase-compat-0.94'] if node['cdap']['version'].to_f < 3.1
 
 pkgs.each do |pkg|
   package pkg do


### PR DESCRIPTION
- Support for HBase 0.98 was added in CDAP 2.6
- Support for HBase 0.94 was dropped in CDAP 3.1
- Remove support for 2.5.9xxx CDAP pre-releases