### PR TITLE
install hbase-compat-1.0 and -cdh packages for cdap 3.1+

### DIFF
--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -22,6 +22,7 @@ include_recipe 'cdap::default'
 # All released versions support HBase 0.96
 pkgs = ['cdap-hbase-compat-0.96']
 pkgs += ['cdap-hbase-compat-0.98'] if node['cdap']['version'].to_f >= 2.6
+pkgs += ['cdap-hbase-compat-1.0', 'cdap-hbase-compat-1.0-cdh'] if node['cdap']['version'].to_f >= 3.1
 pkgs += ['cdap-hbase-compat-0.94'] if node['cdap']['version'].to_f < 3.1
 
 pkgs.each do |pkg|

--- a/spec/master_spec.rb
+++ b/spec/master_spec.rb
@@ -51,5 +51,9 @@ describe 'cdap::master' do
     it 'does not install cdap-hbase-compat-0.98 package' do
       expect(chef_run).not_to install_package('cdap-hbase-compat-0.98')
     end
+
+    it 'does not install cdap-hbase-compat-1.0 package' do
+      expect(chef_run).not_to install_package('cdap-hbase-compat-1.0')
+    end
   end
 end


### PR DESCRIPTION
- [x] adds ``hbase-compat-1.0`` and ``hbase-compat-1.0-cdh`` dependencies for ``master`` install