### PR TITLE
ability to not install prerequisites

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: cdap
+# Attribute:: default
+#
+# Copyright © 2013-2014 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Install Java and Hadoop clients by default
+default['cdap']['skip_prerequisites'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Attribute:: default
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'All rights reserved'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.7.0'
+version          '2.7.1'
 
 %w(apt ark hadoop java nodejs ntp yum yum-epel).each do |cb|
   depends cb

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,29 +17,9 @@
 # limitations under the License.
 #
 
-# We require Java, so include it and add it to Hadoop env
-include_recipe 'java'
-log 'java-home' do
-  message "JAVA_HOME = #{node['java']['java_home']}"
-end
-ENV['JAVA_HOME'] = node['java']['java_home']
-%w(hadoop hbase hive).each do |envfile|
-  node.default[envfile]["#{envfile}_env"]['java_home'] = node['java']['java_home']
-end
-
-# We need Hadoop/HBase installed
-%w(default hbase).each do |recipe|
-  include_recipe "hadoop::#{recipe}"
-end
-
-# Hive is optional
-if node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('explore.enabled') &&
-   node['cdap']['cdap_site']['explore.enabled'].to_s == 'true'
-
-  log 'hive-explore-enabled' do
-    message 'Explore module enabled, installing Hive libraries'
-  end
-  include_recipe 'hadoop::hive'
+# Install Java and Hadoop Clients
+unless node['cdap'].key?('skip_prerequisites') && node['cdap']['skip_prerequisites'].to_s == 'true'
+  include_recipe 'cdap::prerequisites'
 end
 
 include_recipe 'ntp'

--- a/recipes/prerequisites.rb
+++ b/recipes/prerequisites.rb
@@ -1,0 +1,43 @@
+#
+# Cookbook Name:: cdap
+# Recipe:: prerequisites
+#
+# Copyright © 2013-2014 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# We require Java, so include it and add it to Hadoop env
+include_recipe 'java'
+log 'java-home' do
+  message "JAVA_HOME = #{node['java']['java_home']}"
+end
+ENV['JAVA_HOME'] = node['java']['java_home']
+%w(hadoop hbase hive).each do |envfile|
+  node.default[envfile]["#{envfile}_env"]['java_home'] = node['java']['java_home']
+end
+
+# We need Hadoop/HBase installed
+%w(default hbase).each do |recipe|
+  include_recipe "hadoop::#{recipe}"
+end
+
+# Hive is optional
+if node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('explore.enabled') &&
+   node['cdap']['cdap_site']['explore.enabled'].to_s == 'true'
+
+  log 'hive-explore-enabled' do
+    message 'Explore module enabled, installing Hive libraries'
+  end
+  include_recipe 'hadoop::hive'
+end


### PR DESCRIPTION
In some use-cases, it is necessary to not install the hadoop client packages.  For example when running on MapR, this cookbook causes contention with MapR's own hadoop clients.  Therefore, this PR splits the default recipe into two, with an attribute making the prerequisites optional.