### PR TITLE
replace hdfs dfs with the more generic hadoop fs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 Encoding:
   Enabled: False
 LineLength:
-  Max: 250
+  Max: 253
 Documentation:
   Enabled: False
 HashSyntax:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,3 +19,7 @@
 
 # Install Java and Hadoop clients by default
 default['cdap']['skip_prerequisites'] = false
+
+# User to run hdfs commands as
+default['cdap']['fs_superuser'] = 'hdfs'
+

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,5 +20,5 @@
 # Install Java and Hadoop clients by default
 default['cdap']['skip_prerequisites'] = false
 
-# User to run hdfs commands as
+# User to run hadoop fs commands as
 default['cdap']['fs_superuser'] = 'hdfs'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,4 +22,3 @@ default['cdap']['skip_prerequisites'] = false
 
 # User to run hdfs commands as
 default['cdap']['fs_superuser'] = 'hdfs'
-

--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -19,16 +19,16 @@
 
 # We also need the configuration, so we can run HDFS commands
 execute 'initaction-create-hdfs-cdap-dir' do
-  not_if  "hdfs dfs -test -d #{node['cdap']['cdap_site']['hdfs.namespace']}", :user => node['cdap']['cdap_site']['hdfs.user']
-  command "hdfs dfs -mkdir -p #{node['cdap']['cdap_site']['hdfs.namespace']} && hdfs dfs -chown #{node['cdap']['cdap_site']['hdfs.user']} #{node['cdap']['cdap_site']['hdfs.namespace']}"
+  not_if  "hadoop fs -test -d #{node['cdap']['cdap_site']['hdfs.namespace']}", :user => node['cdap']['cdap_site']['hdfs.user']
+  command "hadoop fs -mkdir -p #{node['cdap']['cdap_site']['hdfs.namespace']} && hadoop fs -chown #{node['cdap']['cdap_site']['hdfs.user']} #{node['cdap']['cdap_site']['hdfs.namespace']}"
   timeout 300
   user 'hdfs'
   group 'hdfs'
 end
 
 execute 'initaction-create-hdfs-cdap-user-dir' do
-  not_if  "hdfs dfs -test -d /user/#{node['cdap']['cdap_site']['hdfs.user']}", :user => node['cdap']['cdap_site']['hdfs.user']
-  command "hdfs dfs -mkdir -p /user/#{node['cdap']['cdap_site']['hdfs.user']} && hdfs dfs -chown #{node['cdap']['cdap_site']['hdfs.user']} /user/#{node['cdap']['cdap_site']['hdfs.user']}"
+  not_if  "hadoop fs -test -d /user/#{node['cdap']['cdap_site']['hdfs.user']}", :user => node['cdap']['cdap_site']['hdfs.user']
+  command "hadoop fs -mkdir -p /user/#{node['cdap']['cdap_site']['hdfs.user']} && hadoop fs -chown #{node['cdap']['cdap_site']['hdfs.user']} /user/#{node['cdap']['cdap_site']['hdfs.user']}"
   timeout 300
   user 'hdfs'
   group 'hdfs'
@@ -36,15 +36,15 @@ end
 
 %w(cdap yarn).each do |u|
   execute "initaction-create-hdfs-mr-jhs-staging-intermediate-done-dir-#{u}" do
-    not_if "hdfs dfs -test -d /tmp/hadoop-yarn/staging/history/done_intermediate/#{u}", :user => u
-    command "hdfs dfs -mkdir -p /tmp/hadoop-yarn/staging/history/done_intermediate/#{u} && hdfs dfs -chown #{u} /tmp/hadoop-yarn/staging/history/done_intermediate/#{u} && hdfs dfs -chmod ugo+rx /tmp/hadoop-yarn/staging/history/done_intermediate/#{u}"
+    not_if "hadoop fs -test -d /tmp/hadoop-yarn/staging/history/done_intermediate/#{u}", :user => u
+    command "hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/done_intermediate/#{u} && hadoop fs -chown #{u} /tmp/hadoop-yarn/staging/history/done_intermediate/#{u} && hadoop fs -chmod ugo+rx /tmp/hadoop-yarn/staging/history/done_intermediate/#{u}"
     timeout 300
     user 'hdfs'
     group 'hdfs'
   end
   execute "initaction-create-hdfs-mr-jhs-staging-done-dir-#{u}" do
-    not_if "hdfs dfs -test -d /tmp/hadoop-yarn/staging/history/done/#{u}", :user => u
-    command "hdfs dfs -mkdir -p /tmp/hadoop-yarn/staging/history/done/#{u} && hdfs dfs -chown #{u} /tmp/hadoop-yarn/staging/history/done/#{u} && hdfs dfs -chmod ugo+rx /tmp/hadoop-yarn/staging/history/done/#{u}"
+    not_if "hadoop fs -test -d /tmp/hadoop-yarn/staging/history/done/#{u}", :user => u
+    command "hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/done/#{u} && hadoop fs -chown #{u} /tmp/hadoop-yarn/staging/history/done/#{u} && hadoop fs -chmod ugo+rx /tmp/hadoop-yarn/staging/history/done/#{u}"
     timeout 300
     user 'hdfs'
     group 'hdfs'

--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -22,16 +22,14 @@ execute 'initaction-create-hdfs-cdap-dir' do
   not_if  "hadoop fs -test -d #{node['cdap']['cdap_site']['hdfs.namespace']}", :user => node['cdap']['cdap_site']['hdfs.user']
   command "hadoop fs -mkdir -p #{node['cdap']['cdap_site']['hdfs.namespace']} && hadoop fs -chown #{node['cdap']['cdap_site']['hdfs.user']} #{node['cdap']['cdap_site']['hdfs.namespace']}"
   timeout 300
-  user 'hdfs'
-  group 'hdfs'
+  user node['cdap']['fs_superuser']
 end
 
 execute 'initaction-create-hdfs-cdap-user-dir' do
   not_if  "hadoop fs -test -d /user/#{node['cdap']['cdap_site']['hdfs.user']}", :user => node['cdap']['cdap_site']['hdfs.user']
   command "hadoop fs -mkdir -p /user/#{node['cdap']['cdap_site']['hdfs.user']} && hadoop fs -chown #{node['cdap']['cdap_site']['hdfs.user']} /user/#{node['cdap']['cdap_site']['hdfs.user']}"
   timeout 300
-  user 'hdfs'
-  group 'hdfs'
+  user node['cdap']['fs_superuser']
 end
 
 %w(cdap yarn).each do |u|
@@ -39,14 +37,12 @@ end
     not_if "hadoop fs -test -d /tmp/hadoop-yarn/staging/history/done_intermediate/#{u}", :user => u
     command "hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/done_intermediate/#{u} && hadoop fs -chown #{u} /tmp/hadoop-yarn/staging/history/done_intermediate/#{u} && hadoop fs -chmod ugo+rx /tmp/hadoop-yarn/staging/history/done_intermediate/#{u}"
     timeout 300
-    user 'hdfs'
-    group 'hdfs'
+    user node['cdap']['fs_superuser']
   end
   execute "initaction-create-hdfs-mr-jhs-staging-done-dir-#{u}" do
     not_if "hadoop fs -test -d /tmp/hadoop-yarn/staging/history/done/#{u}", :user => u
     command "hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/done/#{u} && hadoop fs -chown #{u} /tmp/hadoop-yarn/staging/history/done/#{u} && hadoop fs -chmod ugo+rx /tmp/hadoop-yarn/staging/history/done/#{u}"
     timeout 300
-    user 'hdfs'
-    group 'hdfs'
+    user node['cdap']['fs_superuser']
   end
 end


### PR DESCRIPTION
- [x] replace ``hdfs dfs`` invocations with ``hadoop fs`` so that it is more generic and can work with more backends than just hdfs.
- [x] parameterize the fs_superuser to run hadoop commands as