### PR TITLE
add retries to init hadoop fs commands

### DIFF
--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -18,11 +18,14 @@
 #
 
 # We also need the configuration, so we can run HDFS commands
+# Retries allow for orchestration scenarios where HDFS is starting up
 execute 'initaction-create-hdfs-cdap-dir' do
   not_if  "hadoop fs -test -d #{node['cdap']['cdap_site']['hdfs.namespace']}", :user => node['cdap']['cdap_site']['hdfs.user']
   command "hadoop fs -mkdir -p #{node['cdap']['cdap_site']['hdfs.namespace']} && hadoop fs -chown #{node['cdap']['cdap_site']['hdfs.user']} #{node['cdap']['cdap_site']['hdfs.namespace']}"
   timeout 300
   user node['cdap']['fs_superuser']
+  retries 3
+  retry_delay 10
 end
 
 execute 'initaction-create-hdfs-cdap-user-dir' do
@@ -30,6 +33,8 @@ execute 'initaction-create-hdfs-cdap-user-dir' do
   command "hadoop fs -mkdir -p /user/#{node['cdap']['cdap_site']['hdfs.user']} && hadoop fs -chown #{node['cdap']['cdap_site']['hdfs.user']} /user/#{node['cdap']['cdap_site']['hdfs.user']}"
   timeout 300
   user node['cdap']['fs_superuser']
+  retries 3
+  retry_delay 10
 end
 
 %w(cdap yarn).each do |u|
@@ -38,11 +43,15 @@ end
     command "hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/done_intermediate/#{u} && hadoop fs -chown #{u} /tmp/hadoop-yarn/staging/history/done_intermediate/#{u} && hadoop fs -chmod ugo+rx /tmp/hadoop-yarn/staging/history/done_intermediate/#{u}"
     timeout 300
     user node['cdap']['fs_superuser']
+    retries 3
+    retry_delay 10
   end
   execute "initaction-create-hdfs-mr-jhs-staging-done-dir-#{u}" do
     not_if "hadoop fs -test -d /tmp/hadoop-yarn/staging/history/done/#{u}", :user => u
     command "hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/done/#{u} && hadoop fs -chown #{u} /tmp/hadoop-yarn/staging/history/done/#{u} && hadoop fs -chmod ugo+rx /tmp/hadoop-yarn/staging/history/done/#{u}"
     timeout 300
     user node['cdap']['fs_superuser']
+    retries 3
+    retry_delay 10
   end
 end


### PR DESCRIPTION
- [x] adding retries to the hadoop fs initialization commands, to allow time for scenarios where HDFS is still starting up (in read-only mode, etc).