### PR TITLE
check that local user exists before creating hdfs directories for the…

### DIFF
--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -37,7 +37,7 @@ execute 'initaction-create-hdfs-cdap-user-dir' do
   retry_delay 10
 end
 
-%w(cdap yarn).each do |u|
+%w(cdap yarn mapr).each do |u|
   execute "initaction-create-hdfs-mr-jhs-staging-intermediate-done-dir-#{u}" do
     only_if "getent passwd #{u}"
     not_if "hadoop fs -test -d /tmp/hadoop-yarn/staging/history/done_intermediate/#{u}", :user => u

--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -39,6 +39,7 @@ end
 
 %w(cdap yarn).each do |u|
   execute "initaction-create-hdfs-mr-jhs-staging-intermediate-done-dir-#{u}" do
+    only_if "getent passwd #{u}"
     not_if "hadoop fs -test -d /tmp/hadoop-yarn/staging/history/done_intermediate/#{u}", :user => u
     command "hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/done_intermediate/#{u} && hadoop fs -chown #{u} /tmp/hadoop-yarn/staging/history/done_intermediate/#{u} && hadoop fs -chmod ugo+rx /tmp/hadoop-yarn/staging/history/done_intermediate/#{u}"
     timeout 300
@@ -47,6 +48,7 @@ end
     retry_delay 10
   end
   execute "initaction-create-hdfs-mr-jhs-staging-done-dir-#{u}" do
+    only_if "getent passwd #{u}"
     not_if "hadoop fs -test -d /tmp/hadoop-yarn/staging/history/done/#{u}", :user => u
     command "hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/done/#{u} && hadoop fs -chown #{u} /tmp/hadoop-yarn/staging/history/done/#{u} && hadoop fs -chmod ugo+rx /tmp/hadoop-yarn/staging/history/done/#{u}"
     timeout 300


### PR DESCRIPTION
…m.  breaks on MapR

- [x] checks that cdap and yarn users exist locally before running an hdfs chown for them (which will break on MapR)