### PR TITLE
Rename attributes for Kerberos but retain compatibility

### DIFF
--- a/attributes/security.rb
+++ b/attributes/security.rb
@@ -37,8 +37,16 @@ if node['cdap']['cdap_site'].key?('kerberos.auth.enabled') && node['cdap']['cdap
   default_realm = node['krb5']['krb5_conf']['realms']['default_realm'].upcase
 
   # For cdap-master init script
-  default['cdap']['security']['cdap_keytab'] = "#{node['krb5_utils']['keytabs_dir']}/cdap.service.keytab"
-  default['cdap']['security']['cdap_principal'] = "cdap/#{node['fqdn']}@#{default_realm}"
+  if node['cdap'].key?('security') && node['cdap']['security'].key?('cdap_keytab')
+    default['cdap']['kerberos']['cdap_keytab'] = node['cdap']['security']['cdap_keytab']
+  else
+    default['cdap']['kerberos']['cdap_keytab'] = "#{node['krb5_utils']['keytabs_dir']}/cdap.service.keytab"
+  end
+  if node['cdap'].key?('security') && node['cdap']['security'].key?('cdap_principal')
+    default['cdap']['kerberos']['cdap_principal'] = default['cdap']['security']['cdap_principal']
+  else
+    default['cdap']['kerberos']['cdap_principal'] = "cdap/#{node['fqdn']}@#{default_realm}"
+  end
 
   # Add cdap user to YARN container-executor.cfg's allowed.system.users
   if node['hadoop'].key?('container_executor') && node['hadoop']['container_executor'].key?('allowed.system.users')

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -41,12 +41,12 @@ end
 if node['hadoop'].key?('core_site') && node['hadoop']['core_site'].key?('hadoop.security.authentication') &&
    node['hadoop']['core_site']['hadoop.security.authentication'] == 'kerberos'
 
-  if node['cdap'].key?('security') && node['cdap']['security'].key?('cdap_keytab') &&
-     node['cdap']['security'].key?('cdap_principal') &&
+  if node['cdap'].key?('kerberos') && node['cdap']['kerberos'].key?('cdap_keytab') &&
+     node['cdap']['kerberos'].key?('cdap_principal') &&
      node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('kerberos.auth.enabled') &&
      node['cdap']['cdap_site']['kerberos.auth.enabled'].to_s == 'true'
 
-    my_vars = { :options => node['cdap']['security'] }
+    my_vars = { :options => node['cdap']['kerberos'] }
 
     directory '/etc/default' do
       owner 'root'


### PR DESCRIPTION
Otherwise, the CDAP Master's `/etc/default/cdap-master` gets populated with the attributes from `cdap['security']` after #66 was merged.