### PR TITLE
Set SPARK_HOME in cdap-env.sh

### DIFF
--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -64,5 +64,8 @@ hdp_version =
 
 if node['hadoop']['distribution'] == 'hdp' && node['hadoop']['distribution_version'].to_f >= 2.2 && node['cdap']['version'].to_f >= 3.1
   default['cdap']['cdap_env']['opts'] = "${OPTS} -Dhdp.version=#{hdp_version}"
+  default['cdap']['cdap_env']['spark_home'] = "/usr/hdp/#{hdp_version}/spark"
   default['cdap']['cdap_site']['app.program.jvm.opts'] = "-XX:MaxPermSize=128M ${twill.jvm.gc.opts} -Dhdp.version=#{hdp_version}"
+else
+  default['cdap']['cdap_env']['spark_home'] = '/usr/lib/spark'
 end


### PR DESCRIPTION
This setting should be ignored by CDAP if CDAP cannot locate the Spark JARs.