### PR TITLE
Use correct attribute name

### DIFF
--- a/attributes/security.rb
+++ b/attributes/security.rb
@@ -58,11 +58,13 @@ if node['cdap']['cdap_site'].key?('kerberos.auth.enabled') && node['cdap']['cdap
   # Add cdap user to YARN container-executor.cfg's allowed.system.users
   if node['hadoop'].key?('container_executor') && node['hadoop']['container_executor'].key?('allowed.system.users')
     arr = node['hadoop']['container_executor']['allowed.system.users'].split(',')
-    user = node['cdap']['security']['cdap_principal'].split(%r{[@/]}).first
+    user = node['cdap']['kerberos']['cdap_principal'].split(%r{[@/]}).first
     unless arr.include?(user)
       arr += [user]
       default['hadoop']['container_executor']['allowed.system.users'] = arr.join(',')
     end
+  else
+    default['hadoop']['container_executor']['allowed.system.users'] = 'cdap,yarn'
   end
 
   # For cdap-auth-server and cdap-router


### PR DESCRIPTION
The attributes were changed in #76 to use node['cdap']['kerberos']['cdap_principal'] so use that here, too.