### PR TITLE
Ensure backwards compatibility with older roles and default cdap

### DIFF
--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -41,7 +41,7 @@ end
   execute "initaction-create-hdfs-mr-jhs-staging-intermediate-done-dir-#{u}" do
     only_if "getent passwd #{u}"
     not_if "hadoop fs -test -d /tmp/hadoop-yarn/staging/history/done_intermediate/#{u}", :user => u
-    command "hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/done_intermediate/#{u} && hadoop fs -chown #{u} /tmp/hadoop-yarn/staging/history/done_intermediate/#{u} && hadoop fs -chmod ugo+rx /tmp/hadoop-yarn/staging/history/done_intermediate/#{u}"
+    command "hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/done_intermediate/#{u} && hadoop fs -chown #{u} /tmp/hadoop-yarn/staging/history/done_intermediate/#{u} && hadoop fs -chmod 1777 /tmp/hadoop-yarn/staging/history/done_intermediate/#{u}"
     timeout 300
     user node['cdap']['fs_superuser']
     retries 3
@@ -50,7 +50,7 @@ end
   execute "initaction-create-hdfs-mr-jhs-staging-done-dir-#{u}" do
     only_if "getent passwd #{u}"
     not_if "hadoop fs -test -d /tmp/hadoop-yarn/staging/history/done/#{u}", :user => u
-    command "hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/done/#{u} && hadoop fs -chown #{u} /tmp/hadoop-yarn/staging/history/done/#{u} && hadoop fs -chmod ugo+rx /tmp/hadoop-yarn/staging/history/done/#{u}"
+    command "hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/done/#{u} && hadoop fs -chown #{u} /tmp/hadoop-yarn/staging/history/done/#{u} && hadoop fs -chmod 1777 /tmp/hadoop-yarn/staging/history/done/#{u}"
     timeout 300
     user node['cdap']['fs_superuser']
     retries 3

--- a/templates/default/hbase-shell.erb
+++ b/templates/default/hbase-shell.erb
@@ -1,2 +1,2 @@
-grant '<%= node["cdap"]["security"]["cdap_principal"].split(/[@\/]/).first %>', 'ACRW'
+grant '<%= node["cdap"]["kerberos"]["cdap_principal"].split(/[@\/]/).first %>', 'ACRW'
 exit


### PR DESCRIPTION
Also, set sticky bit and 1777 on JHS history directories so `mapred` can read it.