### PR TITLE
Rename repo files to match project and major/minor version

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -17,10 +17,12 @@
 # limitations under the License.
 #
 
+maj_min = node['cdap']['version'].to_f
+
 case node['platform_family']
 when 'debian'
   include_recipe 'apt'
-  apt_repository 'cask' do
+  apt_repository "cdap-#{maj_min}" do
     uri node['cdap']['repo']['apt_repo_url']
     distribution node['lsb']['codename']
     components node['cdap']['repo']['apt_components']
@@ -28,13 +30,19 @@ when 'debian'
     arch 'amd64'
     key "#{node['cdap']['repo']['apt_repo_url']}/pubkey.gpg"
   end
+  file '/etc/apt/sources.list.d/cask.list' do
+    action :delete
+  end
 when 'rhel'
   include_recipe 'yum'
-  yum_repository 'cask' do
-    description 'Cask YUM repository'
+  yum_repository "cdap-#{maj_min}" do
+    description 'CDAP YUM repository'
     url node['cdap']['repo']['yum_repo_url']
     gpgkey "#{node['cdap']['repo']['yum_repo_url']}/pubkey.gpg"
     gpgcheck true
     action :add
+  end
+  file '/etc/yum.repos.d/cask.repo' do
+    action :delete
   end
 end

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -6,8 +6,12 @@ describe 'cdap::repo' do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6).converge(described_recipe)
     end
 
-    it 'adds cask yum repository' do
-      expect(chef_run).to add_yum_repository('cask')
+    it 'adds cdap-3.1 yum repository' do
+      expect(chef_run).to add_yum_repository('cdap-3.1')
+    end
+
+    it 'deletes cask yum repository' do
+      expect(chef_run).to delete_file('/etc/yum.repos.d/cask.repo')
     end
   end
 
@@ -16,8 +20,12 @@ describe 'cdap::repo' do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04).converge(described_recipe)
     end
 
-    it 'adds cask apt repository' do
-      expect(chef_run).to add_apt_repository('cask')
+    it 'adds cdap-3.1 apt repository' do
+      expect(chef_run).to add_apt_repository('cdap-3.1')
+    end
+
+    it 'deletes cask apt repository' do
+      expect(chef_run).to delete_file('/etc/apt/sources.list.d/cask.list')
     end
   end
 end


### PR DESCRIPTION
This changes from `cask` which was incorrect, as we do not have a single repo for all Cask products. This allows for Coopr and CDAP repositories to be installed on a single machine, easily.