### PR TITLE
Default *.keystore.keypassword to *.keystore.password if empty

### DIFF
--- a/recipes/gateway.rb
+++ b/recipes/gateway.rb
@@ -40,7 +40,12 @@ execute 'create-router-ssl-keystore' do
     end
 
   password = node['cdap']['cdap_site']['router.ssl.keystore.password']
-  keypass = node['cdap']['cdap_site']['router.ssl.keystore.keypassword']
+  keypass =
+    if node['cdap']['cdap_site'].key?('router.ssl.keystore.keypassword')
+      node['cdap']['cdap_site']['router.ssl.keystore.keypassword']
+    else
+      node['cdap']['cdap_site']['router.ssl.keystore.password']
+    end
   path = node['cdap']['cdap_site']['router.ssl.keystore.path']
   common_name = node['cdap']['security']['ssl_common_name']
   jks =

--- a/recipes/security.rb
+++ b/recipes/security.rb
@@ -50,7 +50,13 @@ execute 'create-security-server-ssl-keystore' do
     end
 
   password = node['cdap']['cdap_site']['security.server.ssl.keystore.password']
-  keypass = node['cdap']['cdap_site']['security.server.ssl.keystore.keypassword']
+  keypass =
+    if node['cdap']['cdap_site'].key?('security.server.ssl.keystore.keypassword')
+      node['cdap']['cdap_site']['security.server.ssl.keystore.keypassword']
+    else
+      node['cdap']['cdap_site']['security.server.ssl.keystore.password']
+    end
+
   path = node['cdap']['cdap_site']['security.server.ssl.keystore.path']
   common_name = node['cdap']['security']['ssl_common_name']
   jks =


### PR DESCRIPTION
Otherwise the `-dname` is taken as the password, and the dname argument is considered an invalid argument to keytool.