### PR TITLE
Add HDP 2.2.8.0 and 2.3.0.0 to table

### DIFF
--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -59,6 +59,10 @@ hdp_version =
       '2.2.4.4-16'
     when '2.2.6.0'
       '2.2.6.0-2800'
+    when '2.2.8.0'
+      '2.2.8.0-3150'
+    when '2.3.0.0'
+      '2.3.0.0-2557'
     else
       node['hadoop']['distribution_version']
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
 name             'cdap'
 maintainer       'Cask Data, Inc.'
 maintainer_email 'ops@cask.co'
-license          'All rights reserved'
+license          'Apache 2.0'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.15.3'


### PR DESCRIPTION
This allows supporting these releases of HDP via this cookbook using the hadoop cookbook.