### PR TITLE
Update gem dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@
 language: ruby
 rvm:
   - 1.9.3
+  - 2.0.0
   - 2.1.4
 cache: bundler
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,15 @@ gem 'foodcritic', '~> 3.0'
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
-gem 'chef', '< 12.0'
+if RUBY_VERSION.to_f < 2.0
+  gem 'chef', '< 12.0'
+  gem 'varia_model', '< 0.5.0'
+else
+  gem 'chef', '< 12.5' # Testing
+end
+
+gem 'ridley', '~> 4.2.0'
+gem 'faraday', '< 0.9.2'
 
 gem 'rubocop'
 gem 'rubocop-checkstyle_formatter', require: false


### PR DESCRIPTION
Added Ruby 2.0.0 to Travis CI testing.

Version constrained chef, varia_model, ridley, and faraday gems.
See caskdata/hadoop_cookbook#229 for more information.