### PR TITLE
COOK-75 Change default attributes for SSL

### DIFF
--- a/attributes/security.rb
+++ b/attributes/security.rb
@@ -17,10 +17,23 @@
 # limitations under the License.
 #
 
-# auth
-default['cdap']['cdap_site']['security.server.ssl.keystore.password'] = 'defaultpassword'
-default['cdap']['cdap_site']['security.server.ssl.keystore.path'] = '/opt/cdap/security/conf/keystore.jks'
-default['cdap']['cdap_site']['security.auth.server.address'] = node['fqdn']
+# SSL Settings
+if node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled') &&
+   node['cdap']['cdap_site']['ssl.enabled'].to_s == 'true'
+
+  # auth
+  default['cdap']['cdap_security']['security.server.ssl.keystore.password'] = 'somedefaultpassword'
+  default['cdap']['cdap_security']['security.server.ssl.keystore.path'] = '/opt/cdap/security/conf/keystore.jks'
+  default['cdap']['cdap_security']['security.auth.server.address'] = node['fqdn']
+
+  # router
+  default['cdap']['cdap_security']['router.ssl.keystore.password'] = 'somedefaultpassword'
+  default['cdap']['cdap_security']['router.ssl.keystore.path'] = '/opt/cdap/gateway/conf/keystore.jks'
+
+  # web ui
+  default['cdap']['cdap_security']['dashboard.ssl.key'] = "/etc/cdap/#{node['cdap']['conf_dir']}/webapp.key"
+  default['cdap']['cdap_security']['dashboard.ssl.cert'] = "/etc/cdap/#{node['cdap']['conf_dir']}/webapp.crt"
+end
 
 # realmfile creation
 # node['cdap']['cdap_site']['security.authentication.handlerClassName'] must equal 'security.authentication.basic.realmfile'
@@ -29,14 +42,7 @@ default['cdap']['security']['manage_realmfile'] = false
 # realmfile username/passwords
 default['cdap']['security']['realmfile']['cdap'] = 'cdap'
 
-# router
-default['cdap']['cdap_site']['router.ssl.keystore.password'] = 'defaultpassword'
-default['cdap']['cdap_site']['router.ssl.keystore.path'] = '/opt/cdap/gateway/conf/keystore.jks'
-
-# web ui
-default['cdap']['cdap_site']['dashboard.ssl.key'] = "/etc/cdap/#{node['cdap']['conf_dir']}/webapp.key"
-default['cdap']['cdap_site']['dashboard.ssl.cert'] = "/etc/cdap/#{node['cdap']['conf_dir']}/webapp.crt"
-
+# SSL common name
 default['cdap']['security']['ssl_common_name'] = node['fqdn']
 
 if node['cdap']['cdap_site'].key?('kerberos.auth.enabled') && node['cdap']['cdap_site']['kerberos.auth.enabled'].to_s == 'true'

--- a/recipes/gateway.rb
+++ b/recipes/gateway.rb
@@ -39,22 +39,24 @@ execute 'create-router-ssl-keystore' do
       false
     end
 
-  password = node['cdap']['cdap_security']['router.ssl.keystore.password']
-  keypass =
-    if node['cdap']['cdap_security'].key?('router.ssl.keystore.keypassword')
-      node['cdap']['cdap_security']['router.ssl.keystore.keypassword']
-    else
-      node['cdap']['cdap_security']['router.ssl.keystore.password']
-    end
-  path = node['cdap']['cdap_security']['router.ssl.keystore.path']
-  common_name = node['cdap']['security']['ssl_common_name']
-  jks =
-    if node['cdap']['cdap_security'].key?('router.ssl.keystore.type') &&
-       node['cdap']['cdap_security']['router.ssl.keystore.type'] != 'JKS'
-      false
-    else
-      true
-    end
+  if ssl_enabled.to_s == 'true'
+    password = node['cdap']['cdap_security']['router.ssl.keystore.password']
+    keypass =
+      if node['cdap']['cdap_security'].key?('router.ssl.keystore.keypassword')
+        node['cdap']['cdap_security']['router.ssl.keystore.keypassword']
+      else
+        node['cdap']['cdap_security']['router.ssl.keystore.password']
+      end
+    path = node['cdap']['cdap_security']['router.ssl.keystore.path']
+    common_name = node['cdap']['security']['ssl_common_name']
+    jks =
+      if node['cdap']['cdap_security'].key?('router.ssl.keystore.type') &&
+         node['cdap']['cdap_security']['router.ssl.keystore.type'] != 'JKS'
+        false
+      else
+        true
+      end
+  end
 
   command "keytool -genkey -noprompt -alias ext-auth -keysize 2048 -keyalg RSA -keystore #{path} -storepass #{password} -keypass #{keypass} -dname 'CN=#{common_name}, OU=cdap, O=cdap, L=Palo Alto, ST=CA, C=US'"
   not_if { ::File.exist?(path.to_s) }

--- a/recipes/gateway.rb
+++ b/recipes/gateway.rb
@@ -39,17 +39,18 @@ execute 'create-router-ssl-keystore' do
       false
     end
 
-  password = node['cdap']['cdap_site']['router.ssl.keystore.password']
+  password = node['cdap']['cdap_security']['router.ssl.keystore.password']
   keypass =
-    if node['cdap']['cdap_site'].key?('router.ssl.keystore.keypassword')
-      node['cdap']['cdap_site']['router.ssl.keystore.keypassword']
+    if node['cdap']['cdap_security'].key?('router.ssl.keystore.keypassword')
+      node['cdap']['cdap_security']['router.ssl.keystore.keypassword']
     else
-      node['cdap']['cdap_site']['router.ssl.keystore.password']
+      node['cdap']['cdap_security']['router.ssl.keystore.password']
     end
-  path = node['cdap']['cdap_site']['router.ssl.keystore.path']
+  path = node['cdap']['cdap_security']['router.ssl.keystore.path']
   common_name = node['cdap']['security']['ssl_common_name']
   jks =
-    if node['cdap']['cdap_site'].key?('router.ssl.keystore.type') && node['cdap']['cdap_site']['router.ssl.keystore.type'] != 'JKS'
+    if node['cdap']['cdap_security'].key?('router.ssl.keystore.type') &&
+       node['cdap']['cdap_security']['router.ssl.keystore.type'] != 'JKS'
       false
     else
       true

--- a/recipes/security.rb
+++ b/recipes/security.rb
@@ -49,22 +49,24 @@ execute 'create-security-server-ssl-keystore' do
       false
     end
 
-  password = node['cdap']['cdap_security']['security.server.ssl.keystore.password']
-  keypass =
-    if node['cdap']['cdap_security'].key?('security.server.ssl.keystore.keypassword')
-      node['cdap']['cdap_security']['security.server.ssl.keystore.keypassword']
-    else
-      node['cdap']['cdap_security']['security.server.ssl.keystore.password']
-    end
-  path = node['cdap']['cdap_security']['security.server.ssl.keystore.path']
-  common_name = node['cdap']['security']['ssl_common_name']
-  jks =
-    if node['cdap']['cdap_security'].key?('security.server.ssl.keystore.type') &&
-       node['cdap']['cdap_security']['security.server.ssl.keystore.type'] != 'JKS'
-      false
-    else
-      true
-    end
+  if ssl_enabled.to_s == 'true'
+    password = node['cdap']['cdap_security']['security.server.ssl.keystore.password']
+    keypass =
+      if node['cdap']['cdap_security'].key?('security.server.ssl.keystore.keypassword')
+        node['cdap']['cdap_security']['security.server.ssl.keystore.keypassword']
+      else
+        node['cdap']['cdap_security']['security.server.ssl.keystore.password']
+      end
+    path = node['cdap']['cdap_security']['security.server.ssl.keystore.path']
+    common_name = node['cdap']['security']['ssl_common_name']
+    jks =
+      if node['cdap']['cdap_security'].key?('security.server.ssl.keystore.type') &&
+         node['cdap']['cdap_security']['security.server.ssl.keystore.type'] != 'JKS'
+        false
+      else
+        true
+      end
+  end
 
   command "keytool -genkey -noprompt -alias ext-auth -keysize 2048 -keyalg RSA -keystore #{path} -storepass #{password} -keypass #{keypass} -dname 'CN=#{common_name}, OU=cdap, O=cdap, L=Palo Alto, ST=CA, C=US'"
   not_if { ::File.exist?(path.to_s) }

--- a/recipes/security.rb
+++ b/recipes/security.rb
@@ -49,18 +49,18 @@ execute 'create-security-server-ssl-keystore' do
       false
     end
 
-  password = node['cdap']['cdap_site']['security.server.ssl.keystore.password']
+  password = node['cdap']['cdap_security']['security.server.ssl.keystore.password']
   keypass =
-    if node['cdap']['cdap_site'].key?('security.server.ssl.keystore.keypassword')
-      node['cdap']['cdap_site']['security.server.ssl.keystore.keypassword']
+    if node['cdap']['cdap_security'].key?('security.server.ssl.keystore.keypassword')
+      node['cdap']['cdap_security']['security.server.ssl.keystore.keypassword']
     else
-      node['cdap']['cdap_site']['security.server.ssl.keystore.password']
+      node['cdap']['cdap_security']['security.server.ssl.keystore.password']
     end
-  path = node['cdap']['cdap_site']['security.server.ssl.keystore.path']
+  path = node['cdap']['cdap_security']['security.server.ssl.keystore.path']
   common_name = node['cdap']['security']['ssl_common_name']
   jks =
-    if node['cdap']['cdap_site'].key?('security.server.ssl.keystore.type') &&
-       node['cdap']['cdap_site']['security.server.ssl.keystore.type'] != 'JKS'
+    if node['cdap']['cdap_security'].key?('security.server.ssl.keystore.type') &&
+       node['cdap']['cdap_security']['security.server.ssl.keystore.type'] != 'JKS'
       false
     else
       true

--- a/recipes/ui.rb
+++ b/recipes/ui.rb
@@ -73,8 +73,8 @@ execute 'generate-ui-ssl-cert' do
     end
 
   common_name = node['cdap']['security']['ssl_common_name']
-  keypath = node['cdap']['cdap_site']['dashboard.ssl.key']
-  certpath = node['cdap']['cdap_site']['dashboard.ssl.cert']
+  keypath = node['cdap']['cdap_security']['dashboard.ssl.key']
+  certpath = node['cdap']['cdap_security']['dashboard.ssl.cert']
   command "openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout #{keypath} -out #{certpath} -subj '/C=US/ST=CA/L=Palo Alto/OU=cdap/O=cdap/CN=#{common_name}'"
   not_if { File.exist?(certpath) && File.exist?(keypath) }
   only_if { ssl_enabled }

--- a/recipes/ui.rb
+++ b/recipes/ui.rb
@@ -72,9 +72,12 @@ execute 'generate-ui-ssl-cert' do
       false
     end
 
-  common_name = node['cdap']['security']['ssl_common_name']
-  keypath = node['cdap']['cdap_security']['dashboard.ssl.key']
-  certpath = node['cdap']['cdap_security']['dashboard.ssl.cert']
+  if ssl_enabled.to_s == 'true'
+    common_name = node['cdap']['security']['ssl_common_name']
+    keypath = node['cdap']['cdap_security']['dashboard.ssl.key']
+    certpath = node['cdap']['cdap_security']['dashboard.ssl.cert']
+  end
+
   command "openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout #{keypath} -out #{certpath} -subj '/C=US/ST=CA/L=Palo Alto/OU=cdap/O=cdap/CN=#{common_name}'"
   not_if { File.exist?(certpath) && File.exist?(keypath) }
   only_if { ssl_enabled }

--- a/recipes/web_app.rb
+++ b/recipes/web_app.rb
@@ -76,9 +76,12 @@ else
         false
       end
 
-    common_name = node['cdap']['security']['ssl_common_name']
-    keypath = node['cdap']['cdap_security']['dashboard.ssl.key']
-    certpath = node['cdap']['cdap_security']['dashboard.ssl.cert']
+    if ssl_enabled.to_s == 'true'
+      common_name = node['cdap']['security']['ssl_common_name']
+      keypath = node['cdap']['cdap_security']['dashboard.ssl.key']
+      certpath = node['cdap']['cdap_security']['dashboard.ssl.cert']
+    end
+
     command "openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout #{keypath} -out #{certpath} -subj '/C=US/ST=CA/L=Palo Alto/OU=cdap/O=cdap/CN=#{common_name}'"
     not_if { ::File.exist?(certpath.to_s) && ::File.exist?(keypath.to_s) }
     only_if { ssl_enabled.to_s == 'true' }

--- a/recipes/web_app.rb
+++ b/recipes/web_app.rb
@@ -77,8 +77,8 @@ else
       end
 
     common_name = node['cdap']['security']['ssl_common_name']
-    keypath = node['cdap']['cdap_site']['dashboard.ssl.key']
-    certpath = node['cdap']['cdap_site']['dashboard.ssl.cert']
+    keypath = node['cdap']['cdap_security']['dashboard.ssl.key']
+    certpath = node['cdap']['cdap_security']['dashboard.ssl.cert']
     command "openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout #{keypath} -out #{certpath} -subj '/C=US/ST=CA/L=Palo Alto/OU=cdap/O=cdap/CN=#{common_name}'"
     not_if { ::File.exist?(certpath.to_s) && ::File.exist?(keypath.to_s) }
     only_if { ssl_enabled.to_s == 'true' }


### PR DESCRIPTION
Only add attributes if `ssl.enabled` is true, to prevent us from writing out `cdap-security.xml` with default values if it's unused.

Use new attributes in recipes:
- [x] Auth Server (security)
- [x] Router (gateway)
- [x] UI (ui)
- [x] legacy WebApp (webapp)