### PR TITLE
Testing improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'berkshelf', '~> 3.0'
-gem 'foodcritic', '~> 3.0'
+gem 'foodcritic', '~> 4.0'
 
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'

--- a/spec/master_spec.rb
+++ b/spec/master_spec.rb
@@ -13,7 +13,13 @@ describe 'cdap::master' do
     end
     pkg = 'cdap-master'
 
-    %w(cdap-hbase-compat-0.96 cdap-hbase-compat-0.98 cdap-hbase-compat-1.0 cdap-hbase-compat-1.0-cdh).each do |compat|
+    %w(
+      cdap-hbase-compat-0.96
+      cdap-hbase-compat-0.98
+      cdap-hbase-compat-1.0
+      cdap-hbase-compat-1.0-cdh
+      cdap-hbase-compat-1.1
+    ).each do |compat|
       it "installs #{compat} package" do
         expect(chef_run).to install_package(compat)
       end
@@ -52,12 +58,20 @@ describe 'cdap::master' do
       end.converge(described_recipe)
     end
 
+    it 'installs cdap-hbase-compat-0.94 package' do
+      expect(chef_run).to install_package('cdap-hbase-compat-0.94')
+    end
+
     it 'does not install cdap-hbase-compat-0.98 package' do
       expect(chef_run).not_to install_package('cdap-hbase-compat-0.98')
     end
 
     it 'does not install cdap-hbase-compat-1.0 package' do
       expect(chef_run).not_to install_package('cdap-hbase-compat-1.0')
+    end
+
+    it 'does not install cdap-hbase-compat-1.1 package' do
+      expect(chef_run).not_to install_package('cdap-hbase-compat-1.1')
     end
   end
 end

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'cdap::repo' do
-  context 'on Centos 6.6 x86_64' do
+  context 'on Centos 6.6 x86_64 using default version' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6).converge(described_recipe)
     end
@@ -15,7 +15,31 @@ describe 'cdap::repo' do
     end
   end
 
-  context 'on Ubuntu 12.04' do
+  context 'using 2.8.2' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
+        node.override['cdap']['version'] = '2.8.2-1'
+      end.converge(described_recipe)
+    end
+
+    it 'adds cdap-2.8 yum repository' do
+      expect(chef_run).to add_yum_repository('cdap-2.8')
+    end
+  end
+
+  context 'using 2.5.2' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
+        node.override['cdap']['version'] = '2.5.2-1'
+      end.converge(described_recipe)
+    end
+
+    it 'adds cdap-2.5 yum repository' do
+      expect(chef_run).to add_yum_repository('cdap-2.5')
+    end
+  end
+
+  context 'on Ubuntu 12.04 using default version' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04).converge(described_recipe)
     end


### PR DESCRIPTION
Some improvements to increase test coverage and use newer tests.

- Update foodcritic version
- Better tests for `cdap-hbase-compat-0.94` and `cdap-hbase-compat-1.1`
- Test `repo` recipe on CDAP 2.8 and 2.5 versions (for coverage)

Before:
```
ChefSpec Coverage report generated...

  Total Resources:   61
  Touched Resources: 51
  Touch Coverage:    83.61%
```

After:
```
ChefSpec Coverage report generated...

  Total Resources:   61
  Touched Resources: 55
  Touch Coverage:    90.16%
```

Still room for improvement, but this is a step in the right direction.