### PR TITLE
set default security.auth.server.address regardless of ssl setting

### DIFF
--- a/attributes/security.rb
+++ b/attributes/security.rb
@@ -37,7 +37,7 @@ end
 # Auth-Server Settings
 if node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('security.enabled') &&
    node['cdap']['cdap_site']['security.enabled'].to_s == 'true'
-  default['cdap']['cdap_security']['security.auth.server.address'] = node['fqdn']
+  default['cdap']['cdap_site']['security.auth.server.address'] = node['fqdn']
 end
 
 # realmfile creation

--- a/attributes/security.rb
+++ b/attributes/security.rb
@@ -24,7 +24,6 @@ if node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled
   # auth
   default['cdap']['cdap_security']['security.server.ssl.keystore.password'] = 'somedefaultpassword'
   default['cdap']['cdap_security']['security.server.ssl.keystore.path'] = '/opt/cdap/security/conf/keystore.jks'
-  default['cdap']['cdap_security']['security.auth.server.address'] = node['fqdn']
 
   # router
   default['cdap']['cdap_security']['router.ssl.keystore.password'] = 'somedefaultpassword'
@@ -33,6 +32,12 @@ if node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled
   # web ui
   default['cdap']['cdap_security']['dashboard.ssl.key'] = "/etc/cdap/#{node['cdap']['conf_dir']}/webapp.key"
   default['cdap']['cdap_security']['dashboard.ssl.cert'] = "/etc/cdap/#{node['cdap']['conf_dir']}/webapp.crt"
+end
+
+# Auth-Server Settings
+if node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('security.enabled') &&
+   node['cdap']['cdap_site']['security.enabled'].to_s == 'true'
+  default['cdap']['cdap_security']['security.auth.server.address'] = node['fqdn']
 end
 
 # realmfile creation

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -42,4 +42,18 @@ describe 'cdap::default' do
       expect(link).to link_to('/test/logs/cdap')
     end
   end
+
+  context 'when security.enabled' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
+        node.override['cdap']['cdap_site']['security.enabled'] = 'true'
+        stub_command(/update-alternatives --display /).and_return(false)
+        stub_command(/test -L /).and_return(false)
+      end.converge(described_recipe)
+    end
+
+    it 'includes security recipe' do
+      expect(chef_run).to include_recipe('cdap::security')
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/caskdata/cdap_cookbook/commit/726a1dfd075a5e88d9f6d46ab5e011bb9b0e66ef changed the default behavior, where ``default['cdap']['cdap_security']['security.auth.server.address'] = node['fqdn']`` used to be set by default, it is now only set if ``ssl.enabled`` is true.  However it shouldn't depend on SSL.

This PR sets the default if ``security.enabled`` is true.
