### PR TITLE
Update checksum for 3.2.2 SDK

### DIFF
--- a/attributes/sdk.rb
+++ b/attributes/sdk.rb
@@ -50,7 +50,7 @@ default['cdap']['sdk']['checksum'] =
   when '3.2.1'
     '565dd06caf3201e964dba5ccde1148842d159d297b87ecab51c40249715ebcf5'
   when '3.2.2'
-    '2d36e36936a84c73d38f4ef6e52e2c7a0772e5de0e1cf73ab657e5b63585591b'
+    '0ee53307bd6bbd126e19848f28ca45f1cfe7ef155e48ba36b30fddbb8b8730d3'
   end
 default['cdap']['sdk']['install_path'] = '/opt/cdap'
 default['cdap']['sdk']['user'] = 'cdap'

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
   "recipes": {
 
   },
-  "version": "2.17.0",
+  "version": "2.17.1",
   "source_url": "https://github.com/caskdata/cdap_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10603"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.17.0'
+version          '2.17.1'
 
 %w(apt ark hadoop java nodejs ntp yum yum-epel).each do |cb|
   depends cb


### PR DESCRIPTION
The checksum was for a prerelease version of the SDK file.