### PR TITLE
Support CDAP 3.3.0 and make it default

### DIFF
--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Attribute:: config
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@
 
 # Default: conf.chef
 default['cdap']['conf_dir'] = 'conf.chef'
-# Default: 3.2.1-1
-default['cdap']['version'] = '3.2.2-1'
+# Default: 3.3.0-1
+default['cdap']['version'] = '3.3.0-1'
 # cdap-site.xml
 default['cdap']['cdap_site']['root.namespace'] = 'cdap'
 # ideally we could put the macro '/${cdap.namespace}' here but this attribute is used elsewhere in the cookbook

--- a/attributes/sdk.rb
+++ b/attributes/sdk.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Attribute:: sdk
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,6 +51,8 @@ default['cdap']['sdk']['checksum'] =
     '565dd06caf3201e964dba5ccde1148842d159d297b87ecab51c40249715ebcf5'
   when '3.2.2'
     '0ee53307bd6bbd126e19848f28ca45f1cfe7ef155e48ba36b30fddbb8b8730d3'
+  when '3.3.0'
+    '19ff27493bb79fa377fc10dc57c08e66ce7836fa3696b09a13dd416150ad40c4'
   end
 default['cdap']['sdk']['install_path'] = '/opt/cdap'
 default['cdap']['sdk']['user'] = 'cdap'

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -6,8 +6,8 @@ describe 'cdap::repo' do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6).converge(described_recipe)
     end
 
-    it 'adds cdap-3.2 yum repository' do
-      expect(chef_run).to add_yum_repository('cdap-3.2')
+    it 'adds cdap-3.3 yum repository' do
+      expect(chef_run).to add_yum_repository('cdap-3.3')
     end
 
     it 'deletes cask yum repository' do
@@ -44,8 +44,8 @@ describe 'cdap::repo' do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04).converge(described_recipe)
     end
 
-    it 'adds cdap-3.2 apt repository' do
-      expect(chef_run).to add_apt_repository('cdap-3.2')
+    it 'adds cdap-3.3 apt repository' do
+      expect(chef_run).to add_apt_repository('cdap-3.3')
     end
 
     it 'deletes cask apt repository' do


### PR DESCRIPTION
We love new CDAP releases! Support the latest one and make it default for new installations.