### PR TITLE
Support HDP 2.3.4.7 and 2.4.0.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ Documentation:
   Enabled: False
 HashSyntax:
   Enabled: False
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Enabled: false
 AsciiComments:
   Enabled: false

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -69,6 +69,10 @@ hdp_version =
       '2.3.2.0-2950'
     when '2.3.4.0'
       '2.3.4.0-3485'
+    when '2.3.4.7'
+      '2.3.4.7-4'
+    when '2.4.0.0'
+      '2.4.0.0-169'
     else
       node['hadoop']['distribution_version']
     end


### PR DESCRIPTION
This adds support for the latest HDP 2.3 patches and HDP 2.4 release. It requires https://github.com/caskdata/hadoop_cookbook/pull/250 to be merged and released before this can be used with the `hadoop` cookbook.