### PR TITLE
remove unecessary inclusion of yum::default

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: repo
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ when 'debian'
     action :delete
   end
 when 'rhel'
-  include_recipe 'yum'
   yum_repository "cdap-#{maj_min}" do
     description 'CDAP YUM repository'
     url node['cdap']['repo']['yum_repo_url']


### PR DESCRIPTION
similar to https://github.com/caskdata/hadoop_cookbook/pull/254

- [x] removing the inclusion of the ``yum::default`` recipe, as it is not necessary to use the LWRPs, and causes chef to manage ``/etc/yum.conf`` which may not always be desirable