### PR TITLE
Do not install Node.js on CDAP 3.4+

### DIFF
--- a/recipes/ui.rb
+++ b/recipes/ui.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: ui
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,11 +17,14 @@
 # limitations under the License.
 #
 
-include_recipe 'nodejs::default'
-link '/usr/bin/node' do
-  to '/usr/local/bin/node'
-  action :create
-  not_if 'test -e /usr/bin/node'
+# Starting with CDAP 3.4, we ship Node.js with the cdap-ui package
+if node['cdap']['version'].to_f < 3.4
+  include_recipe 'nodejs::default'
+  link '/usr/bin/node' do
+    to '/usr/local/bin/node'
+    action :create
+    not_if 'test -e /usr/bin/node'
+  end
 end
 
 include_recipe 'cdap::repo'

--- a/spec/ui_spec.rb
+++ b/spec/ui_spec.rb
@@ -40,11 +40,12 @@ describe 'cdap::ui' do
     end
   end
 
-  context 'using older nodejs cookbook' do
+  context 'using older nodejs cookbook on CDAP 3.3' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
         node.default['cdap']['repo']['url'] = 'https://USER:PASS@cdap.repo/path/to/repo'
+        node.override['cdap']['version'] = '3.3.3'
         node.default['hadoop']['hdfs_site']['dfs.datanode.max.transfer.threads'] = '4096'
         node.default['hadoop']['mapred_site']['mapreduce.framework.name'] = 'yarn'
         stub_command(/update-alternatives --display /).and_return(false)


### PR DESCRIPTION
Starting with caskdata/cdap#5522 and release 3.4.0, CDAP ships its own version of Node.js in the `cdap-ui` package. This means we do not have to manage it, ourselves.