### PR TITLE
COOK-98 Add CDAP SDK bin to PATH

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,4 +4,11 @@ group :integration do
   cookbook 'minitest-handler'
 end
 
+# Restrict version due to Chef 12 requirement
+if RUBY_VERSION.to_f < 2.0
+  # cookbook 'mingw', '< 1.0'
+  cookbook 'build-essential', '< 3.0'
+  cookbook 'ohai', '< 4.0'
+end
+
 metadata

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'berkshelf', '~> 3.0'
 gem 'foodcritic', '~> 4.0'
 
-gem 'chefspec', '~> 4.0'
+gem 'chefspec', '~> 4.0', '< 4.7'
 gem 'rspec', '~> 3.0'
 
 if RUBY_VERSION.to_f < 2.0

--- a/recipes/sdk.rb
+++ b/recipes/sdk.rb
@@ -66,6 +66,16 @@ template '/etc/init.d/cdap-sdk' do
   variables node['cdap']['sdk']
 end
 
+# COOK-98
+template '/etc/profile.d/cdap-sdk.sh' do
+  source 'generic-env.sh.erb'
+  mode 0644
+  owner 'root'
+  group 'root'
+  action :create
+  variables :options => { 'path' => "${PATH}:#{node['cdap']['sdk']['install_path']}/sdk/bin" }
+end
+
 service 'cdap-sdk' do
   action node['cdap']['sdk']['init_actions']
 end


### PR DESCRIPTION
This adds the CDAP SDK bin directory to the system's PATH for login shells.