### PR TITLE
Add checksum for CDAP 3.4.2 SDK

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,12 +1,8 @@
-source 'https://supermarket.getchef.com'
-
-group :integration do
-  cookbook 'minitest-handler'
-end
+source 'https://supermarket.chef.io'
 
 # Restrict version due to Chef 12 requirement
 if RUBY_VERSION.to_f < 2.0
-  # cookbook 'mingw', '< 1.0'
+  cookbook 'apt', '< 4.0'
   cookbook 'build-essential', '< 3.0'
   cookbook 'ohai', '< 4.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,13 @@ source 'https://rubygems.org'
 gem 'berkshelf', '~> 3.0'
 gem 'foodcritic', '~> 4.0'
 
-gem 'chefspec', '~> 4.0', '< 4.7'
+gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
 if RUBY_VERSION.to_f < 2.0
   gem 'chef', '< 12.0'
   gem 'varia_model', '< 0.5.0'
+  gem 'fauxhai', '< 3.5.0'
 else
   gem 'chef', '< 12.5' # Testing
 end
@@ -17,7 +18,6 @@ gem 'chef-zero', '< 4.6' if RUBY_VERSION.to_f < 2.1
 
 gem 'ridley', '~> 4.2.0'
 gem 'faraday', '< 0.9.2'
-
 gem 'rubocop'
 gem 'rubocop-checkstyle_formatter', require: false
 gem 'rainbow', '<= 1.99.1'

--- a/attributes/sdk.rb
+++ b/attributes/sdk.rb
@@ -65,6 +65,8 @@ default['cdap']['sdk']['checksum'] =
     '1876673b010ff6e795418272ed3ecf171fae340b6f489fea8f6b2d3fe0d42e3f'
   when '3.4.1'
     '82c31e1e6d5b371ea7dedf79f2cd9be9cd4ba8a3cfe3ef36ff2cd7b38fc91a4d'
+  when '3.4.2'
+    '6103e5d7f3fa2f91057511703f12fa513235e6f5ff52d4e10ead4bbc8727954c'
   end
 default['cdap']['sdk']['install_path'] = '/opt/cdap'
 default['cdap']['sdk']['user'] = 'cdap'


### PR DESCRIPTION
This allows installing the released 3.4.2 CDAP SDK using the cookbook.