### PR TITLE
Only restart SDK if actions include start

### DIFF
--- a/recipes/sdk.rb
+++ b/recipes/sdk.rb
@@ -73,7 +73,7 @@ ark 'sdk' do
   version ver
   owner node['cdap']['sdk']['user']
   group node['cdap']['sdk']['user']
-  notifies :restart, 'service[cdap-sdk]', :delayed if node['cdap']['sdk']['init_actions'].include(:start)
+  notifies :restart, 'service[cdap-sdk]', :delayed if node['cdap']['sdk']['init_actions'].include?(:start)
 end
 
 service 'cdap-sdk' do

--- a/recipes/sdk.rb
+++ b/recipes/sdk.rb
@@ -46,17 +46,6 @@ user node['cdap']['sdk']['user'] do
   only_if { node['cdap']['sdk']['manage_user'].to_s == 'true' }
 end
 
-ark 'sdk' do
-  url node['cdap']['sdk']['url']
-  prefix_root ark_prefix_path
-  prefix_home ark_prefix_path
-  checksum node['cdap']['sdk']['checksum']
-  version ver
-  owner node['cdap']['sdk']['user']
-  group node['cdap']['sdk']['user']
-  notifies :restart, 'service[cdap-sdk]', :delayed
-end
-
 template '/etc/init.d/cdap-sdk' do
   source 'cdap-service.erb'
   mode 0755
@@ -74,6 +63,17 @@ template '/etc/profile.d/cdap-sdk.sh' do
   group 'root'
   action :create
   variables :options => { 'path' => "${PATH}:#{node['cdap']['sdk']['install_path']}/sdk/bin" }
+end
+
+ark 'sdk' do
+  url node['cdap']['sdk']['url']
+  prefix_root ark_prefix_path
+  prefix_home ark_prefix_path
+  checksum node['cdap']['sdk']['checksum']
+  version ver
+  owner node['cdap']['sdk']['user']
+  group node['cdap']['sdk']['user']
+  notifies :restart, 'service[cdap-sdk]', :delayed if node['cdap']['sdk']['init_actions'].include(:start)
 end
 
 service 'cdap-sdk' do


### PR DESCRIPTION
Otherwise, we may restart an SDK that we did not intend on starting. Also, move to after writing out init script template, so it'll be on disk before any restart occurs.