### PR TITLE
COOK-102 Rewrite distribution to Precise

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -33,7 +33,7 @@ if node['cdap'].key?('cdap_site')
 
   template "#{cdap_conf_dir}/cdap-site.xml" do
     source 'generic-site.xml.erb'
-    mode 0644
+    mode 0o644
     owner 'cdap'
     group 'cdap'
     variables my_vars
@@ -47,7 +47,7 @@ if node['cdap'].key?('cdap_security')
 
   template "#{cdap_conf_dir}/cdap-security.xml" do
     source 'generic-site.xml.erb'
-    mode 0600
+    mode 0o600
     owner 'cdap'
     group 'cdap'
     variables my_vars
@@ -61,7 +61,7 @@ if node['cdap'].key?('cdap_env') && node['cdap']['version'].to_f >= 2.7
 
   template "#{cdap_conf_dir}/cdap-env.sh" do
     source 'generic-env.sh.erb'
-    mode 0644
+    mode 0o644
     owner 'cdap'
     group 'cdap'
     variables my_vars

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,7 +30,7 @@ file '/etc/profile.d/cdap_home.sh' do
     export CDAP_HOME=/opt/cdap
     export PATH=$PATH:$CDAP_HOME/bin
   EOS
-  mode 0755
+  mode 0o755
 end
 
 package 'cdap' do

--- a/recipes/gateway.rb
+++ b/recipes/gateway.rb
@@ -74,7 +74,7 @@ svcs.each do |svc|
   attrib = svc.gsub('cdap-', '').tr('-', '_')
   template "/etc/init.d/#{svc}" do
     source 'cdap-service.erb'
-    mode 0755
+    mode 0o755
     owner 'root'
     group 'root'
     action :create

--- a/recipes/kafka.rb
+++ b/recipes/kafka.rb
@@ -34,7 +34,7 @@ kafka_log_dir =
 node.default['cdap']['cdap_site']['kafka.log.dir'] = kafka_log_dir
 
 directory kafka_log_dir do
-  mode 0755
+  mode 0o755
   owner 'cdap'
   group 'cdap'
   action :create
@@ -43,7 +43,7 @@ end
 
 template '/etc/init.d/cdap-kafka-server' do
   source 'cdap-service.erb'
-  mode 0755
+  mode 0o755
   owner 'root'
   group 'root'
   action :create

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -107,7 +107,7 @@ end
 
 template '/etc/init.d/cdap-master' do
   source 'cdap-service.erb'
-  mode 0755
+  mode 0o755
   owner 'root'
   group 'root'
   action :create

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -22,9 +22,15 @@ maj_min = node['cdap']['version'].to_f
 case node['platform_family']
 when 'debian'
   include_recipe 'apt'
+  codename = node['lsb']['codename']
+  case codename
+  when 'raring', 'saucy', 'trusty'
+    codename = 'precise'
+    Chef::Log.warn('Overriding repository distribution to Precise')
+  end
   apt_repository "cdap-#{maj_min}" do
     uri node['cdap']['repo']['apt_repo_url']
-    distribution node['lsb']['codename']
+    distribution codename
     components node['cdap']['repo']['apt_components']
     action :add
     arch 'amd64'

--- a/recipes/sdk.rb
+++ b/recipes/sdk.rb
@@ -48,7 +48,7 @@ end
 
 template '/etc/init.d/cdap-sdk' do
   source 'cdap-service.erb'
-  mode 0755
+  mode 0o755
   owner 'root'
   group 'root'
   action :create
@@ -58,7 +58,7 @@ end
 # COOK-98
 template '/etc/profile.d/cdap-sdk.sh' do
   source 'generic-env.sh.erb'
-  mode 0644
+  mode 0o644
   owner 'root'
   group 'root'
   action :create

--- a/recipes/security.rb
+++ b/recipes/security.rb
@@ -27,7 +27,7 @@ end
 
 template '/etc/init.d/cdap-auth-server' do
   source 'cdap-service.erb'
-  mode 0755
+  mode 0o755
   owner 'root'
   group 'root'
   action :create
@@ -90,7 +90,7 @@ if node['cdap']['security']['manage_realmfile'].to_s == 'true' &&
   # Create the realmfile
   template realmfile do
     source 'generic-kv-colon.erb'
-    mode 0644
+    mode 0o644
     owner 'cdap'
     group 'cdap'
     variables options: node['cdap']['security']['realmfile']

--- a/recipes/ui.rb
+++ b/recipes/ui.rb
@@ -56,7 +56,7 @@ end
 
 template '/etc/init.d/cdap-ui' do
   source 'cdap-service.erb'
-  mode 0755
+  mode 0o755
   owner 'root'
   group 'root'
   action :create

--- a/recipes/web_app.rb
+++ b/recipes/web_app.rb
@@ -57,7 +57,7 @@ else
 
   template '/etc/init.d/cdap-web-app' do
     source 'cdap-service.erb'
-    mode 0755
+    mode 0o755
     owner 'root'
     group 'root'
     action :create


### PR DESCRIPTION
CDAP should work without modification on Ubuntu releases through 14.04 (Trusty) just by adjusting the APT repository file. This does that.