### PR TITLE
version bump to 2.21.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
   "recipes": {
 
   },
-  "version": "2.21.0",
+  "version": "2.21.1",
   "source_url": "https://github.com/caskdata/cdap_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10603"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.21.0'
+version          '2.21.1'
 
 %w(apt ark hadoop java nodejs ntp yum yum-epel).each do |cb|
   depends cb


### PR DESCRIPTION
version bump for 2.21.1 release.

changes are all bugfixes:  3.4.2 sdk hash, fix start behavior, trusty/etc support:
https://github.com/caskdata/cdap_cookbook/pull/136
https://github.com/caskdata/cdap_cookbook/pull/137
https://github.com/caskdata/cdap_cookbook/pull/138