### PR TITLE
Recipe to install cdap-ambari-service on Ambari

### DIFF
--- a/attributes/ambari.rb
+++ b/attributes/ambari.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: cdap
+# Attribute:: ambari
+#
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+default['cdap']['ambari']['version'] = '3.4.1-1'
+default['cdap']['ambari']['install'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.21.1'
 
-%w(apt ark hadoop java nodejs ntp yum yum-epel).each do |cb|
+%w(ambari apt ark hadoop java nodejs ntp yum yum-epel).each do |cb|
   depends cb
 end
 

--- a/recipes/ambari.rb
+++ b/recipes/ambari.rb
@@ -1,0 +1,27 @@
+#
+# Cookbook Name:: cdap
+# Recipe:: ambari
+#
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'cdap::repo'
+include_recipe 'ambari::server' if node['cdap']['ambari']['install'].to_s == 'true'
+
+package 'cdap-ambari-service' do
+  action :install
+  version node['cdap']['ambari']['version']
+  notifies :restart, 'service[ambari-server]', :delayed if node['cdap']['ambari']['install'].to_s == 'true'
+end


### PR DESCRIPTION
This will optionally install Ambari Server and restart the service. Otherwise, it's up to the administrator to restart Ambari after running this recipe.