### PR TITLE
Support CDAP SDK 3.4.3 installation

### DIFF
--- a/attributes/sdk.rb
+++ b/attributes/sdk.rb
@@ -69,6 +69,8 @@ default['cdap']['sdk']['checksum'] =
     '82c31e1e6d5b371ea7dedf79f2cd9be9cd4ba8a3cfe3ef36ff2cd7b38fc91a4d'
   when '3.4.2'
     '6103e5d7f3fa2f91057511703f12fa513235e6f5ff52d4e10ead4bbc8727954c'
+  when '3.4.3'
+    'b834eda1137f8423aec2e45dd917f14b86009cfa061c6487f3d20ae29017db8d'
   end
 default['cdap']['sdk']['install_path'] = '/opt/cdap'
 default['cdap']['sdk']['user'] = 'cdap'


### PR DESCRIPTION
This adds the checksum for the CDAP 3.4.3 SDK artifact.