### PR TITLE
Remove deprecated init recipes from Test Kitchen

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -73,32 +73,22 @@ platforms:
 suites:
   - name: cdh4
     run_list:
-      - recipe[cdap::security_init]
-      - recipe[cdap::web_app_init]
       - recipe[cdap::fullstack]
     attributes: { hadoop: { distribution: 'cdh', distribution_version: '4.7.1' } }
   - name: cdh5
     run_list:
-      - recipe[cdap::security_init]
-      - recipe[cdap::web_app_init]
       - recipe[cdap::fullstack]
     attributes: { hadoop: { distribution: 'cdh', distribution_version: '5.4.1' } }
   - name: hdp20
     run_list:
-      - recipe[cdap::security_init]
-      - recipe[cdap::web_app_init]
       - recipe[cdap::fullstack]
     attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.0.11.0' } }
   - name: hdp21
     run_list:
-      - recipe[cdap::security_init]
-      - recipe[cdap::web_app_init]
       - recipe[cdap::fullstack]
     attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.1.10.0' } }
   - name: hdp22
     run_list:
-      - recipe[cdap::security_init]
-      - recipe[cdap::web_app_init]
       - recipe[cdap::fullstack]
     attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.2.4.2' } }
   - name: sdk


### PR DESCRIPTION
The `cdap::security_init` and `cdap::web_app_init` recipes are deprecated and should not be used.