### PR TITLE
Update test kitchen

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -73,32 +73,22 @@ platforms:
 suites:
   - name: cdh4
     run_list:
-      - recipe[cdap::security_init]
-      - recipe[cdap::web_app_init]
       - recipe[cdap::fullstack]
     attributes: { hadoop: { distribution: 'cdh', distribution_version: '4.7.1' } }
   - name: cdh5
     run_list:
-      - recipe[cdap::security_init]
-      - recipe[cdap::web_app_init]
       - recipe[cdap::fullstack]
     attributes: { hadoop: { distribution: 'cdh', distribution_version: '5.4.1' } }
   - name: hdp20
     run_list:
-      - recipe[cdap::security_init]
-      - recipe[cdap::web_app_init]
       - recipe[cdap::fullstack]
     attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.0.11.0' } }
   - name: hdp21
     run_list:
-      - recipe[cdap::security_init]
-      - recipe[cdap::web_app_init]
       - recipe[cdap::fullstack]
     attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.1.10.0' } }
   - name: hdp22
     run_list:
-      - recipe[cdap::security_init]
-      - recipe[cdap::web_app_init]
       - recipe[cdap::fullstack]
     attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.2.4.2' } }
   - name: sdk

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,6 +17,8 @@ provisioner:
         init_actions: 'start'
       router:
         init_actions: 'start'
+      sdk:
+        init_actions: 'start'
       security:
         init_actions: 'start'
       ui:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -55,3 +55,11 @@ suites:
   - name: sdk
     run_list:
       - recipe[cdap::sdk]
+  - name: ambari
+    attributes: { cdap: { ambari: { install: true } } }
+    run_list:
+      - recipe[cdap::ambari]
+    excludes:
+      - debian-6.0.10
+      - ubuntu-12.04
+      - ubuntu-14.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,8 +11,6 @@ provisioner:
   require_chef_omnibus: true
   attributes:
     cdap:
-      gateway:
-        init_actions: 'start'
       kafka:
         init_actions: 'start'
       master:
@@ -22,8 +20,6 @@ provisioner:
       security:
         init_actions: 'start'
       ui:
-        init_actions: 'start'
-      web_app:
         init_actions: 'start'
 
 platforms:
@@ -71,10 +67,6 @@ platforms:
          'hive.zookeeper.quorum': 'localhost'
 
 suites:
-  - name: cdh4
-    run_list:
-      - recipe[cdap::fullstack]
-    attributes: { hadoop: { distribution: 'cdh', distribution_version: '4.7.1' } }
   - name: cdh5
     run_list:
       - recipe[cdap::fullstack]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,65 +21,32 @@ provisioner:
         init_actions: 'start'
       ui:
         init_actions: 'start'
+    hadoop:
+      hdfs_site:
+       'dfs.datanode.max.transfer.threads': 4096
+    hive:
+      hive_site:
+       'hive.support.concurrency': true
+       'hive.zookeeper.quorum': 'localhost'
 
 platforms:
   - name: centos-6.6
-    attributes:
-      hadoop:
-        hdfs_site:
-         'dfs.datanode.max.transfer.threads': 4096
-      hive:
-        hive_site:
-         'hive.support.concurrency': true
-         'hive.zookeeper.quorum': 'localhost'
   - name: debian-6.0.10
     run_list:
     - apt::default
-    attributes:
-      hadoop:
-        hdfs_site:
-         'dfs.datanode.max.transfer.threads': 4096
-      hive:
-        hive_site:
-         'hive.support.concurrency': true
-         'hive.zookeeper.quorum': 'localhost'
   - name: ubuntu-12.04
     run_list:
     - apt::default
-    attributes:
-      hadoop:
-        hdfs_site:
-         'dfs.datanode.max.transfer.threads': 4096
-      hive:
-        hive_site:
-         'hive.support.concurrency': true
-         'hive.zookeeper.quorum': 'localhost'
   - name: ubuntu-14.04
     run_list:
     - apt::default
-    attributes:
-      hadoop:
-        hdfs_site:
-         'dfs.datanode.max.transfer.threads': 4096
-      hive:
-        hive_site:
-         'hive.support.concurrency': true
-         'hive.zookeeper.quorum': 'localhost'
 
 suites:
   - name: cdh5
     run_list:
       - recipe[cdap::fullstack]
     attributes: { hadoop: { distribution: 'cdh', distribution_version: '5.4.1' } }
-  - name: hdp20
-    run_list:
-      - recipe[cdap::fullstack]
-    attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.0.11.0' } }
-  - name: hdp21
-    run_list:
-      - recipe[cdap::fullstack]
-    attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.1.10.0' } }
-  - name: hdp22
+  - name: hdp2
     run_list:
       - recipe[cdap::fullstack]
     attributes: { hadoop: { distribution: 'hdp', distribution_version: '2.2.4.2' } }

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ else
 end
 
 gem 'chef-zero', '< 4.6' if RUBY_VERSION.to_f < 2.1
+gem 'ffi-yajl', '< 2.3' if RUBY_VERSION.to_f < 2.1
 gem 'rack', '< 2.0' if RUBY_VERSION.to_f < 2.2
 gem 'ridley', '~> 4.2.0'
 gem 'faraday', '< 0.9.2'

--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,10 @@ if RUBY_VERSION.to_f < 2.0
   gem 'varia_model', '< 0.5.0'
   gem 'fauxhai', '< 3.5.0'
   gem 'json', '< 2.0'
+  gem 'rubocop', '< 0.42'
 else
   gem 'chef', '< 12.5' # Testing
+  gem 'rubocop'
 end
 
 gem 'chef-zero', '< 4.6' if RUBY_VERSION.to_f < 2.1
@@ -20,8 +22,6 @@ gem 'ffi-yajl', '< 2.3' if RUBY_VERSION.to_f < 2.1
 gem 'rack', '< 2.0' if RUBY_VERSION.to_f < 2.2
 gem 'ridley', '~> 4.2.0'
 gem 'faraday', '< 0.9.2'
-gem 'rubocop'
-gem 'rubocop-checkstyle_formatter', require: false
 gem 'rainbow', '<= 1.99.1'
 
 group :integration do


### PR DESCRIPTION
This dramatically simplifies the Test Kitchen configuration.

- [x] Spin up only 1 version of CDH/HDP
- [x] Start SDK
- [x] Make attributes global (don't affect `ambari` or `sdk` anyway
- [x] Add `ambari` recipe test (CentOS 6 only)