### PR TITLE
Switch Ambari dependency to recommends

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ if RUBY_VERSION.to_f < 2.0
   gem 'json', '< 2.0'
   gem 'rubocop', '< 0.42'
   gem 'varia_model', '< 0.5.0'
-  gem 'foodcritic', '~> 6.0', '< 6.3'
+  gem 'foodcritic', '~> 4.0'
 else
   gem 'chef', '< 12.5'
   gem 'foodcritic', '~> 6.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,28 +1,35 @@
 source 'https://rubygems.org'
 
 gem 'berkshelf', '~> 3.0'
-gem 'foodcritic', '~> 4.0'
 
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
+if RUBY_VERSION.to_f < 2.1
+  gem 'buff-ignore', '< 1.2'
+  gem 'chef-zero', '< 4.6'
+  gem 'fauxhai', '< 3.5'
+  gem 'ffi-yajl', '< 2.3'
+  gem 'dep_selector', '< 1.0.4'
+end
+
 if RUBY_VERSION.to_f < 2.0
   gem 'chef', '< 12.0'
-  gem 'varia_model', '< 0.5.0'
-  gem 'fauxhai', '< 3.5.0'
   gem 'json', '< 2.0'
   gem 'rubocop', '< 0.42'
+  gem 'varia_model', '< 0.5.0'
+  gem 'foodcritic', '~> 6.0', '< 6.3'
 else
-  gem 'chef', '< 12.5' # Testing
+  gem 'chef', '< 12.5'
+  gem 'foodcritic', '~> 6.0'
   gem 'rubocop'
 end
 
-gem 'chef-zero', '< 4.6' if RUBY_VERSION.to_f < 2.1
-gem 'ffi-yajl', '< 2.3' if RUBY_VERSION.to_f < 2.1
 gem 'rack', '< 2.0' if RUBY_VERSION.to_f < 2.2
 gem 'ridley', '~> 4.2.0'
 gem 'faraday', '< 0.9.2'
 gem 'rainbow', '<= 1.99.1'
+gem 'dep-selector-libgecode', '< 1.3.1'
 
 group :integration do
   gem 'test-kitchen'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,11 +6,12 @@ description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.22.0'
 
-%w(ambari apt ark hadoop java nodejs ntp yum yum-epel).each do |cb|
+%w(apt ark hadoop java nodejs ntp yum yum-epel).each do |cb|
   depends cb
 end
 
 depends 'krb5_utils'
+recommends 'ambari'
 
 %w(amazon centos debian redhat scientific ubuntu).each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ version          '2.22.0'
 end
 
 depends 'krb5_utils'
-recommends 'ambari'
+recommends 'ambari' # ~FC053
 
 %w(amazon centos debian redhat scientific ubuntu).each do |os|
   supports os

--- a/recipes/ambari.rb
+++ b/recipes/ambari.rb
@@ -18,7 +18,7 @@
 #
 
 include_recipe 'cdap::repo'
-include_recipe 'ambari::server' if node['cdap']['ambari']['install'].to_s == 'true'
+include_recipe 'ambari::server' if node['cdap']['ambari']['install'].to_s == 'true' # ~FC007
 
 package 'cdap-ambari-service' do
   action :install


### PR DESCRIPTION
Since `ambari` isn't used in the normal `cdap::fullstack` usage and isn't necessary in the default configuration, change it from a dependency to just a recommends.