### PR TITLE
Support new cdap script for CDAP 4.0+

### DIFF
--- a/attributes/sdk.rb
+++ b/attributes/sdk.rb
@@ -81,8 +81,8 @@ default['cdap']['sdk']['init_name'] = 'SDK'
 default['cdap']['sdk']['init_krb5'] = false
 default['cdap']['sdk']['init_cmd'] =
   if node['cdap']['version'].to_f < 4.0
-    "#{node['cdap']['sdk']['install_path']}/sdk/bin/cdap sdk"
-  else
     "#{node['cdap']['sdk']['install_path']}/sdk/bin/cdap.sh"
+  else
+    "#{node['cdap']['sdk']['install_path']}/sdk/bin/cdap sdk"
   end
 default['cdap']['sdk']['init_actions'] = [:enable, :start]

--- a/attributes/sdk.rb
+++ b/attributes/sdk.rb
@@ -79,5 +79,10 @@ default['cdap']['sdk']['user'] = 'cdap'
 default['cdap']['sdk']['manage_user'] = true
 default['cdap']['sdk']['init_name'] = 'SDK'
 default['cdap']['sdk']['init_krb5'] = false
-default['cdap']['sdk']['init_cmd'] = "#{node['cdap']['sdk']['install_path']}/sdk/bin/cdap.sh"
+default['cdap']['sdk']['init_cmd'] =
+  if node['cdap']['version'].to_f < 4.0
+    "#{node['cdap']['sdk']['install_path']}/sdk/bin/cdap sdk"
+  else
+    "#{node['cdap']['sdk']['install_path']}/sdk/bin/cdap.sh"
+  end
 default['cdap']['sdk']['init_actions'] = [:enable, :start]

--- a/attributes/services.rb
+++ b/attributes/services.rb
@@ -28,35 +28,60 @@ name = 'kafka'
 default['cdap'][name]['user'] = 'cdap'
 default['cdap'][name]['init_name'] = 'Kafka Server'
 default['cdap'][name]['init_krb5'] = false
-default['cdap'][name]['init_cmd'] = "/opt/cdap/#{name}/bin/svc-#{name}-server"
+default['cdap'][name]['init_cmd'] =
+  if node['cdap']['version'].to_f < 4.0
+    "/opt/cdap/#{name}/bin/svc-#{name}-server"
+  else
+    "/opt/cdap/#{name}/bin/cdap #{name}-server"
+  end
 default['cdap'][name]['init_actions'] = [:nothing]
 
 name = 'master'
 default['cdap'][name]['user'] = 'cdap'
 default['cdap'][name]['init_name'] = name.split.map(&:capitalize).join(' ')
 default['cdap'][name]['init_krb5'] = true
-default['cdap'][name]['init_cmd'] = "/opt/cdap/#{name}/bin/svc-#{name}"
+default['cdap'][name]['init_cmd'] =
+  if node['cdap']['version'].to_f < 4.0
+    "/opt/cdap/#{name}/bin/svc-#{name}"
+  else
+    "/opt/cdap/#{name}/bin/cdap #{name}"
+  end
 default['cdap'][name]['init_actions'] = [:nothing]
 
 name = 'router'
 default['cdap'][name]['user'] = 'cdap'
 default['cdap'][name]['init_name'] = name.split.map(&:capitalize).join(' ')
 default['cdap'][name]['init_krb5'] = false
-default['cdap'][name]['init_cmd'] = "/opt/cdap/gateway/bin/svc-#{name}"
+default['cdap'][name]['init_cmd'] =
+  if node['cdap']['version'].to_f < 4.0
+    "/opt/cdap/#{name}/bin/svc-#{name}"
+  else
+    "/opt/cdap/#{name}/bin/cdap #{name}"
+  end
 default['cdap'][name]['init_actions'] = [:nothing]
 
 name = 'security'
 default['cdap'][name]['user'] = 'cdap'
 default['cdap'][name]['init_name'] = 'Auth Server'
 default['cdap'][name]['init_krb5'] = false
-default['cdap'][name]['init_cmd'] = "/opt/cdap/#{name}/bin/svc-auth-server"
+default['cdap'][name]['init_cmd'] =
+  if node['cdap']['version'].to_f < 4.0
+    "/opt/cdap/#{name}/bin/svc-auth-server"
+  else
+    "/opt/cdap/#{name}/bin/cdap auth-server"
+  end
 default['cdap'][name]['init_actions'] = [:nothing]
 
 name = 'ui'
 default['cdap'][name]['user'] = 'cdap'
 default['cdap'][name]['init_name'] = name.upcase
 default['cdap'][name]['init_krb5'] = false
-default['cdap'][name]['init_cmd'] = "/opt/cdap/#{name}/bin/svc-#{name}"
+default['cdap'][name]['init_cmd'] =
+  if node['cdap']['version'].to_f < 4.0
+    "/opt/cdap/#{name}/bin/svc-#{name}"
+  else
+    "/opt/cdap/#{name}/bin/cdap #{name}"
+  end
 default['cdap'][name]['init_actions'] = [:nothing]
 
 name = 'web_app'

--- a/templates/default/cdap-service.erb
+++ b/templates/default/cdap-service.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright © 2014-2015 Cask Data, Inc.
+# Copyright © 2014-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -37,6 +37,12 @@ if [[ -r /etc/default/cdap-<%= @init_name.downcase.gsub(' ', '-') %> ]]; then
   . /etc/default/cdap-<%= @init_name.downcase.gsub(' ', '-') %>
 fi
 
+# source cdap-env.sh, if it exists
+CDAP_CONF=${CDAP_CONF:-/etc/cdap/conf}
+if [[ -r ${CDAP_CONF}/cdap-env.sh ]]; then
+  . "${CDAP_CONF}"/cdap-env.sh
+fi
+
 # how about jdk.sh
 if [[ -r /etc/profile.d/jdk.sh ]]; then
   . /etc/profile.d/jdk.sh
@@ -57,13 +63,18 @@ if [[ -r $CDAP_KEYTAB ]] && [[ -n $CDAP_PRINCIPAL ]]; then
 fi
 
 <% end %>
-# drop permissions to cdap user and run service script
+CDAP_USER=${CDAP_USER:-<%= @user %>}
+
+# drop permissions to CDAP_USER and run service script
 
 if [[ $UID -eq 0 ]]; then
-    su <%= @user %> -c "$SVC_COMMAND"
-    ret=$?
+  su ${CDAP_USER} -c "${SVC_COMMAND}"
+  ret=$?
+elif [[ ${USER} == ${CDAP_USER} ]]; then
+  ${SVC_COMMAND}
+  ret=$?
 else
-    $SVC_COMMAND
-    ret=$?
+  echo "ERROR: Must run this script as root or ${CDAP_USER}!"
+  ret=1
 fi
 exit $ret

--- a/templates/default/cdap-service.erb
+++ b/templates/default/cdap-service.erb
@@ -66,7 +66,6 @@ fi
 CDAP_USER=${CDAP_USER:-<%= @user %>}
 
 # drop permissions to CDAP_USER and run service script
-
 if [[ $UID -eq 0 ]]; then
   su ${CDAP_USER} -c "${SVC_COMMAND}"
   ret=$?


### PR DESCRIPTION
This is to support the upcoming caskdata/cdap/#6574 (CDAP-1280) changes, where the individual scripts in CDAP will be replaced with a single script, called `cdap` which serves as a wrapper for all CDAP functions. This also brings the `cdap-service.erb` template up-to-date with the current CDAP scripts, which allow running CDAP as a configurable CDAP_USER.

Old:
`/opt/cdap/${component}/bin/svc-${service} start`

New:
`/opt/cdap/${component}/bin/cdap ${service} start`