### PR TITLE
Add checksums for CDAP 3.3.7 and 3.5.0 SDK

### DIFF
--- a/attributes/sdk.rb
+++ b/attributes/sdk.rb
@@ -65,6 +65,8 @@ default['cdap']['sdk']['checksum'] =
     '953b9b7244e8075c78881695d9efb3dbd43f30e98adeafb0e28b857c98e142fd'
   when '3.3.6'
     '2ae37dc2cebc4c0f99b80a0437e1af52053180e82ad66b6951bf02d16e952345'
+  when '3.3.7'
+    '46ab798d11db9cf44dfc2abd66d5c6e0575331a84ae78a500663da9538c854e6'
   when '3.4.0'
     '1876673b010ff6e795418272ed3ecf171fae340b6f489fea8f6b2d3fe0d42e3f'
   when '3.4.1'
@@ -73,6 +75,8 @@ default['cdap']['sdk']['checksum'] =
     '6103e5d7f3fa2f91057511703f12fa513235e6f5ff52d4e10ead4bbc8727954c'
   when '3.4.3'
     'b834eda1137f8423aec2e45dd917f14b86009cfa061c6487f3d20ae29017db8d'
+  when '3.5.0'
+    '883c91073c5658a73e5603eea62bd95516521cef9ae4ed8382f724777714b24b'
   end
 default['cdap']['sdk']['install_path'] = '/opt/cdap'
 default['cdap']['sdk']['user'] = 'cdap'


### PR DESCRIPTION
Support CDAP 3.3.7 and 3.5.0 SDK installations.