### PR TITLE
Feature/3 5 default

### DIFF
--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -19,8 +19,8 @@
 
 # Default: conf.chef
 default['cdap']['conf_dir'] = 'conf.chef'
-# Default: 3.4.3-1
-default['cdap']['version'] = '3.4.3-1'
+# Default: 3.5.0-1
+default['cdap']['version'] = '3.5.0-1'
 # cdap-site.xml
 default['cdap']['cdap_site']['root.namespace'] = 'cdap'
 # ideally we could put the macro '/${cdap.namespace}' here but this attribute is used elsewhere in the cookbook

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -26,9 +26,15 @@ default['cdap']['cdap_site']['root.namespace'] = 'cdap'
 # ideally we could put the macro '/${cdap.namespace}' here but this attribute is used elsewhere in the cookbook
 default['cdap']['cdap_site']['hdfs.namespace'] = "/#{node['cdap']['cdap_site']['root.namespace']}"
 default['cdap']['cdap_site']['hdfs.user'] = 'yarn'
-default['cdap']['cdap_site']['kafka.log.dir'] = '/data/cdap/kafka-logs'
 default['cdap']['cdap_site']['kafka.seed.brokers'] = "#{node['fqdn']}:9092"
-default['cdap']['cdap_site']['kafka.default.replication.factor'] = '1'
+# CDAP 3.5.0 deprecated Kafka Server settings
+if node['cdap']['version'].to_f < 3.5
+  default['cdap']['cdap_site']['kafka.log.dir'] = '/data/cdap/kafka-logs'
+  default['cdap']['cdap_site']['kafka.default.replication.factor'] = '1'
+else
+  default['cdap']['cdap_site']['kafka.server.log.dirs'] = '/data/cdap/kafka-logs'
+  default['cdap']['cdap_site']['kafka.server.default.replication.factor'] = '1'
+end
 default['cdap']['cdap_site']['log.retention.duration.days'] = '7'
 default['cdap']['cdap_site']['zookeeper.quorum'] = "#{node['fqdn']}:2181/#{node['cdap']['cdap_site']['root.namespace']}"
 default['cdap']['cdap_site']['router.bind.address'] = node['fqdn']

--- a/attributes/sdk.rb
+++ b/attributes/sdk.rb
@@ -73,6 +73,8 @@ default['cdap']['sdk']['checksum'] =
     '6103e5d7f3fa2f91057511703f12fa513235e6f5ff52d4e10ead4bbc8727954c'
   when '3.4.3'
     'b834eda1137f8423aec2e45dd917f14b86009cfa061c6487f3d20ae29017db8d'
+  when '3.5.0'
+    '883c91073c5658a73e5603eea62bd95516521cef9ae4ed8382f724777714b24b'
   end
 default['cdap']['sdk']['install_path'] = '/opt/cdap'
 default['cdap']['sdk']['user'] = 'cdap'

--- a/recipes/kafka.rb
+++ b/recipes/kafka.rb
@@ -31,7 +31,7 @@ end
 kafka_log_dirs =
   if node['cdap']['cdap_site'].key?('kafka.server.log.dirs')
     node['cdap']['cdap_site']['kafka.server.log.dirs']
-  elsif node['cdap']['version'].to_f < 3.5 && node['cdap']['cdap_site'].key?('kafka.log.dir')
+  elsif node['cdap']['cdap_site'].key?('kafka.log.dir')
     node['cdap']['cdap_site']['kafka.log.dir']
   else
     '/tmp/kafka-logs'

--- a/recipes/kafka.rb
+++ b/recipes/kafka.rb
@@ -24,21 +24,29 @@ package 'cdap-kafka' do
   version node['cdap']['version']
 end
 
-kafka_log_dir =
-  if node['cdap']['cdap_site'].key?('kafka.log.dir')
+if node['cdap']['version'].to_f >= 3.5 && node['cdap']['cdap_site'].key?('kafka.log.dir')
+  Chef::Log.warn('kafka.log.dir has been deprecated. Please use kafka.server.log.dirs instead.')
+end
+
+kafka_log_dirs =
+  if node['cdap']['cdap_site'].key?('kafka.server.log.dirs')
+    node['cdap']['cdap_site']['kafka.server.log.dirs']
+  elsif node['cdap']['version'].to_f < 3.5 && node['cdap']['cdap_site'].key?('kafka.log.dir')
     node['cdap']['cdap_site']['kafka.log.dir']
   else
     '/tmp/kafka-logs'
   end
 
-node.default['cdap']['cdap_site']['kafka.log.dir'] = kafka_log_dir
+node.default['cdap']['cdap_site']['kafka.server.log.dirs'] = kafka_log_dirs
 
-directory kafka_log_dir do
-  mode 0o755
-  owner 'cdap'
-  group 'cdap'
-  action :create
-  recursive true
+kafka_log_dirs.split(',').each do |kafka_log_dir|
+  directory kafka_log_dir do
+    mode 0o755
+    owner 'cdap'
+    group 'cdap'
+    action :create
+    recursive true
+  end
 end
 
 template '/etc/init.d/cdap-kafka-server' do

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -6,8 +6,8 @@ describe 'cdap::repo' do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6).converge(described_recipe)
     end
 
-    it 'adds cdap-3.4 yum repository' do
-      expect(chef_run).to add_yum_repository('cdap-3.4')
+    it 'adds cdap-3.5 yum repository' do
+      expect(chef_run).to add_yum_repository('cdap-3.5')
     end
 
     it 'deletes cask yum repository' do
@@ -44,8 +44,8 @@ describe 'cdap::repo' do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04).converge(described_recipe)
     end
 
-    it 'adds cdap-3.4 apt repository' do
-      expect(chef_run).to add_apt_repository('cdap-3.4')
+    it 'adds cdap-3.5 apt repository' do
+      expect(chef_run).to add_apt_repository('cdap-3.5')
     end
 
     it 'deletes cask apt repository' do


### PR DESCRIPTION
Updates for CDAP 3.5.0 release
- [x] sets default CDAP version to ``3.5.0-1``
- [x] adds checksum for ``3.5.0`` sdk
- [x] adds logic to prefer the new ``kafka.server.log.dirs`` over the deprecated ``kafka.log.dir`` configuration