### PR TITLE
Revert changes to init scripts until caskdata/cdap#6574 is merged

### DIFF
--- a/attributes/sdk.rb
+++ b/attributes/sdk.rb
@@ -83,10 +83,10 @@ default['cdap']['sdk']['user'] = 'cdap'
 default['cdap']['sdk']['manage_user'] = true
 default['cdap']['sdk']['init_name'] = 'SDK'
 default['cdap']['sdk']['init_krb5'] = false
-default['cdap']['sdk']['init_cmd'] =
-  if node['cdap']['version'].to_f < 4.0
-    "#{node['cdap']['sdk']['install_path']}/sdk/bin/cdap.sh"
-  else
-    "#{node['cdap']['sdk']['install_path']}/sdk/bin/cdap sdk"
-  end
+default['cdap']['sdk']['init_cmd'] = "#{node['cdap']['sdk']['install_path']}/sdk/bin/cdap.sh"
+#   if node['cdap']['version'].to_f < 4.0
+#     "#{node['cdap']['sdk']['install_path']}/sdk/bin/cdap.sh"
+#   else
+#     "#{node['cdap']['sdk']['install_path']}/sdk/bin/cdap sdk"
+#   end
 default['cdap']['sdk']['init_actions'] = [:enable, :start]

--- a/attributes/services.rb
+++ b/attributes/services.rb
@@ -28,60 +28,60 @@ name = 'kafka'
 default['cdap'][name]['user'] = 'cdap'
 default['cdap'][name]['init_name'] = 'Kafka Server'
 default['cdap'][name]['init_krb5'] = false
-default['cdap'][name]['init_cmd'] =
-  if node['cdap']['version'].to_f < 4.0
-    "/opt/cdap/#{name}/bin/svc-#{name}-server"
-  else
-    "/opt/cdap/#{name}/bin/cdap #{name}-server"
-  end
+default['cdap'][name]['init_cmd'] = "/opt/cdap/#{name}/bin/svc-#{name}-server"
+#   if node['cdap']['version'].to_f < 4.0
+#     "/opt/cdap/#{name}/bin/svc-#{name}-server"
+#   else
+#     "/opt/cdap/#{name}/bin/cdap #{name}-server"
+#   end
 default['cdap'][name]['init_actions'] = [:nothing]
 
 name = 'master'
 default['cdap'][name]['user'] = 'cdap'
 default['cdap'][name]['init_name'] = name.split.map(&:capitalize).join(' ')
 default['cdap'][name]['init_krb5'] = true
-default['cdap'][name]['init_cmd'] =
-  if node['cdap']['version'].to_f < 4.0
-    "/opt/cdap/#{name}/bin/svc-#{name}"
-  else
-    "/opt/cdap/#{name}/bin/cdap #{name}"
-  end
+default['cdap'][name]['init_cmd'] = "/opt/cdap/#{name}/bin/svc-#{name}"
+#   if node['cdap']['version'].to_f < 4.0
+#     "/opt/cdap/#{name}/bin/svc-#{name}"
+#   else
+#     "/opt/cdap/#{name}/bin/cdap #{name}"
+#   end
 default['cdap'][name]['init_actions'] = [:nothing]
 
 name = 'router'
 default['cdap'][name]['user'] = 'cdap'
 default['cdap'][name]['init_name'] = name.split.map(&:capitalize).join(' ')
 default['cdap'][name]['init_krb5'] = false
-default['cdap'][name]['init_cmd'] =
-  if node['cdap']['version'].to_f < 4.0
-    "/opt/cdap/gateway/bin/svc-#{name}"
-  else
-    "/opt/cdap/gateway/bin/cdap #{name}"
-  end
+default['cdap'][name]['init_cmd'] = "/opt/cdap/gateway/bin/svc-#{name}"
+#   if node['cdap']['version'].to_f < 4.0
+#     "/opt/cdap/gateway/bin/svc-#{name}"
+#   else
+#     "/opt/cdap/gateway/bin/cdap #{name}"
+#   end
 default['cdap'][name]['init_actions'] = [:nothing]
 
 name = 'security'
 default['cdap'][name]['user'] = 'cdap'
 default['cdap'][name]['init_name'] = 'Auth Server'
 default['cdap'][name]['init_krb5'] = false
-default['cdap'][name]['init_cmd'] =
-  if node['cdap']['version'].to_f < 4.0
-    "/opt/cdap/#{name}/bin/svc-auth-server"
-  else
-    "/opt/cdap/#{name}/bin/cdap auth-server"
-  end
+default['cdap'][name]['init_cmd'] = "/opt/cdap/#{name}/bin/svc-auth-server"
+#   if node['cdap']['version'].to_f < 4.0
+#     "/opt/cdap/#{name}/bin/svc-auth-server"
+#   else
+#     "/opt/cdap/#{name}/bin/cdap auth-server"
+#   end
 default['cdap'][name]['init_actions'] = [:nothing]
 
 name = 'ui'
 default['cdap'][name]['user'] = 'cdap'
 default['cdap'][name]['init_name'] = name.upcase
 default['cdap'][name]['init_krb5'] = false
-default['cdap'][name]['init_cmd'] =
-  if node['cdap']['version'].to_f < 4.0
-    "/opt/cdap/#{name}/bin/svc-#{name}"
-  else
-    "/opt/cdap/#{name}/bin/cdap #{name}"
-  end
+default['cdap'][name]['init_cmd'] = "/opt/cdap/#{name}/bin/svc-#{name}"
+#   if node['cdap']['version'].to_f < 4.0
+#     "/opt/cdap/#{name}/bin/svc-#{name}"
+#   else
+#     "/opt/cdap/#{name}/bin/cdap #{name}"
+#   end
 default['cdap'][name]['init_actions'] = [:nothing]
 
 name = 'web_app'

--- a/chefignore
+++ b/chefignore
@@ -45,6 +45,7 @@ a.out
 
 # Testing #
 ###########
+.foodcritic
 .watchr
 .rspec
 .rubocop.yml


### PR DESCRIPTION
Do not support the new init script style until caskdata/cdap#6574 is merged. Otherwise, VM and Docker builds from the `develop` branch of CDAP fail.