### PR TITLE
Version bump to 2.23.2

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
   "recipes": {
 
   },
-  "version": "2.23.1",
+  "version": "2.23.2",
   "source_url": "https://github.com/caskdata/cdap_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10603"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.23.1'
+version          '2.23.2'
 
 %w(apt ark hadoop java nodejs ntp yum yum-epel).each do |cb|
   depends cb


### PR DESCRIPTION
Version bump for release. This includes a fix which prevents the CDAP VM and Docker images from being built (uses `cdap::sdk`) on CDAP's `develop` branch.