### PR TITLE
Version bump to 2.24.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
   "recipes": {
 
   },
-  "version": "2.23.2",
+  "version": "2.24.0",
   "source_url": "https://github.com/caskdata/cdap_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10603"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.23.2'
+version          '2.24.0'
 
 %w(apt ark hadoop java nodejs ntp yum yum-epel).each do |cb|
   depends cb


### PR DESCRIPTION
Includes:

- Use latest released cdap-ambari-service version (#157)
- Rename LICENSE to LICENSE.txt (#160)
- Support IBM Open Platform (IOP) (#161)