### PR TITLE
Lots of small cleanups, DRY up more code

### DIFF
--- a/attributes/services.rb
+++ b/attributes/services.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Attribute:: services
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,13 +40,6 @@ name = 'master'
 default['cdap'][name]['user'] = 'cdap'
 default['cdap'][name]['init_name'] = name.split.map(&:capitalize).join(' ')
 default['cdap'][name]['init_krb5'] = true
-default['cdap'][name]['init_cmd'] =
-  if node['cdap']['version'].to_f < 4.0
-    "/opt/cdap/#{name}/bin/svc-#{name}"
-  else
-    "/opt/cdap/#{name}/bin/cdap #{name}"
-  end
-default['cdap'][name]['init_actions'] = [:nothing]
 
 name = 'router'
 default['cdap'][name]['user'] = 'cdap'
@@ -76,13 +69,16 @@ name = 'ui'
 default['cdap'][name]['user'] = 'cdap'
 default['cdap'][name]['init_name'] = name.upcase
 default['cdap'][name]['init_krb5'] = false
-default['cdap'][name]['init_cmd'] =
-  if node['cdap']['version'].to_f < 4.0
-    "/opt/cdap/#{name}/bin/svc-#{name}"
-  else
-    "/opt/cdap/#{name}/bin/cdap #{name}"
-  end
-default['cdap'][name]['init_actions'] = [:nothing]
+
+%w(master ui).each do |svc|
+  default['cdap'][svc]['init_cmd'] =
+    if node['cdap']['version'].to_f < 4.0
+      "/opt/cdap/#{svc}/bin/svc-#{svc}"
+    else
+      "/opt/cdap/#{svc}/bin/cdap #{svc}"
+    end
+  default['cdap'][svc]['init_actions'] = [:nothing]
+end
 
 name = 'web_app'
 default['cdap'][name]['user'] = 'cdap'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,7 +30,7 @@ file '/etc/profile.d/cdap_home.sh' do
     export CDAP_HOME=/opt/cdap
     export PATH=$PATH:$CDAP_HOME/bin
   EOS
-  mode 0o755
+  mode '0755'
 end
 
 package 'cdap' do

--- a/recipes/gateway.rb
+++ b/recipes/gateway.rb
@@ -74,7 +74,7 @@ svcs.each do |svc|
   attrib = svc.gsub('cdap-', '').tr('-', '_')
   template "/etc/init.d/#{svc}" do
     source 'cdap-service.erb'
-    mode 0o755
+    mode '0755'
     owner 'root'
     group 'root'
     action :create

--- a/recipes/kafka.rb
+++ b/recipes/kafka.rb
@@ -41,7 +41,7 @@ node.default['cdap']['cdap_site']['kafka.server.log.dirs'] = kafka_log_dirs
 
 kafka_log_dirs.split(',').each do |kafka_log_dir|
   directory kafka_log_dir do
-    mode 0o755
+    mode '0755'
     owner 'cdap'
     group 'cdap'
     action :create
@@ -51,7 +51,7 @@ end
 
 template '/etc/init.d/cdap-kafka-server' do
   source 'cdap-service.erb'
-  mode 0o755
+  mode '0755'
   owner 'root'
   group 'root'
   action :create

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -107,7 +107,7 @@ end
 
 template '/etc/init.d/cdap-master' do
   source 'cdap-service.erb'
-  mode 0o755
+  mode '0755'
   owner 'root'
   group 'root'
   action :create

--- a/recipes/prerequisites.rb
+++ b/recipes/prerequisites.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: prerequisites
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ log 'java-home' do
   message "JAVA_HOME = #{node['java']['java_home']}"
 end
 ENV['JAVA_HOME'] = node['java']['java_home']
-%w(hadoop hbase hive).each do |envfile|
+%w(hadoop hbase hive zookeeper).each do |envfile|
   node.default[envfile]["#{envfile}_env"]['java_home'] = node['java']['java_home']
 end
 

--- a/recipes/sdk.rb
+++ b/recipes/sdk.rb
@@ -48,7 +48,7 @@ end
 
 template '/etc/init.d/cdap-sdk' do
   source 'cdap-service.erb'
-  mode 0o755
+  mode '0755'
   owner 'root'
   group 'root'
   action :create
@@ -58,7 +58,7 @@ end
 # COOK-98
 template '/etc/profile.d/cdap-sdk.sh' do
   source 'generic-env.sh.erb'
-  mode 0o644
+  mode '0644'
   owner 'root'
   group 'root'
   action :create

--- a/recipes/security.rb
+++ b/recipes/security.rb
@@ -27,7 +27,7 @@ end
 
 template '/etc/init.d/cdap-auth-server' do
   source 'cdap-service.erb'
-  mode 0o755
+  mode '0755'
   owner 'root'
   group 'root'
   action :create

--- a/recipes/ui.rb
+++ b/recipes/ui.rb
@@ -34,29 +34,9 @@ package 'cdap-ui' do
   version node['cdap']['version']
 end
 
-if node['cdap'].key?('ui')
-  my_vars = { :options => node['cdap']['ui'] }
-
-  directory '/etc/default' do
-    owner 'root'
-    group 'root'
-    mode '0755'
-    action :create
-  end
-
-  template '/etc/default/cdap-ui' do
-    source 'generic-env.sh.erb'
-    mode '0755'
-    owner 'root'
-    group 'root'
-    action :create
-    variables my_vars
-  end # End /etc/default/cdap-ui
-end
-
 template '/etc/init.d/cdap-ui' do
   source 'cdap-service.erb'
-  mode 0o755
+  mode '0755'
   owner 'root'
   group 'root'
   action :create

--- a/recipes/web_app.rb
+++ b/recipes/web_app.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: web_app
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,29 +35,9 @@ else
     version node['cdap']['version']
   end
 
-  if node['cdap'].key?('web_app')
-    my_vars = { :options => node['cdap']['web_app'] }
-
-    directory '/etc/default' do
-      owner 'root'
-      group 'root'
-      mode '0755'
-      action :create
-    end
-
-    template '/etc/default/cdap-web-app' do
-      source 'generic-env.sh.erb'
-      mode '0755'
-      owner 'root'
-      group 'root'
-      action :create
-      variables my_vars
-    end # End /etc/default/cdap-web-app
-  end
-
   template '/etc/init.d/cdap-web-app' do
     source 'cdap-service.erb'
-    mode 0o755
+    mode '0755'
     owner 'root'
     group 'root'
     action :create


### PR DESCRIPTION
- Generate master/ui init_command the same
- Create tx_snapshot_dir at the same time as other dirs
- Set JAVA_HOME for zookeeper
- Remove ui and web_app files from /etc/default, as cdap-env.sh provides same functionality
- Use string for modes