### PR TITLE
update realm file to an empty hash

### DIFF
--- a/attributes/security.rb
+++ b/attributes/security.rb
@@ -51,7 +51,8 @@ end
 # node['cdap']['cdap_site']['security.authentication.basic.realmfile'] must define the realmfile location
 default['cdap']['security']['manage_realmfile'] = false
 # realmfile username/passwords
-default['cdap']['security']['realmfile']['cdap'] = 'cdap'
+# default['cdap']['security']['realmfile']['username'] = 'password'
+default['cdap']['security']['realmfile'] = {}
 
 # SSL common name
 default['cdap']['security']['ssl_common_name'] = node['fqdn']

--- a/recipes/security_realm_file.rb
+++ b/recipes/security_realm_file.rb
@@ -18,7 +18,7 @@
 #
 
 # Manage Authentication realmfile
-if node['cdap']['cdap_site']['security.authentication.basic.realmfile']
+if node['cdap']['cdap_site'].key?(['security.authentication.basic.realmfile']) && !node['cdap']['security']['realmfile'].empty?
   realmfile = node['cdap']['cdap_site']['security.authentication.basic.realmfile']
   realmdir = ::File.dirname(realmfile)
 

--- a/recipes/security_realm_file.rb
+++ b/recipes/security_realm_file.rb
@@ -18,7 +18,7 @@
 #
 
 # Manage Authentication realmfile
-if node['cdap']['cdap_site'].key?(['security.authentication.basic.realmfile']) && !node['cdap']['security']['realmfile'].empty?
+if node['cdap']['cdap_site'].key?('security.authentication.basic.realmfile') && !node['cdap']['security']['realmfile'].empty?
   realmfile = node['cdap']['cdap_site']['security.authentication.basic.realmfile']
   realmdir = ::File.dirname(realmfile)
 


### PR DESCRIPTION
Update the realm file attribute to use an empty hash to prevent the CDAP user from always being in the realm file. 