### PR TITLE
Refactor for less code duplication

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,20 @@
 Encoding:
   Enabled: False
 LineLength:
-  Max: 253
+  Max: 600
 Documentation:
   Enabled: False
 HashSyntax:
   Enabled: False
-SpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false
 AsciiComments:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Metrics/PerceivedComplexity:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ if RUBY_VERSION.to_f < 2.1
   gem 'fauxhai', '< 3.5'
   gem 'ffi-yajl', '< 2.3'
   gem 'dep_selector', '< 1.0.4'
+  gem 'net-http-persistent', '< 3.0'
 end
 
 if RUBY_VERSION.to_f < 2.0

--- a/attributes/security.rb
+++ b/attributes/security.rb
@@ -24,21 +24,12 @@ if node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('security.se
 end
 
 # SSL Settings
-if node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled') &&
-   node['cdap']['cdap_site']['ssl.enabled'].to_s == 'true'
-
-  # auth
-  default['cdap']['cdap_security']['security.server.ssl.keystore.password'] = 'somedefaultpassword'
-  default['cdap']['cdap_security']['security.server.ssl.keystore.path'] = '/opt/cdap/security/conf/keystore.jks'
-
-  # router
-  default['cdap']['cdap_security']['router.ssl.keystore.password'] = 'somedefaultpassword'
-  default['cdap']['cdap_security']['router.ssl.keystore.path'] = '/opt/cdap/gateway/conf/keystore.jks'
-
-  # web ui
-  default['cdap']['cdap_security']['dashboard.ssl.key'] = "/etc/cdap/#{node['cdap']['conf_dir']}/webapp.key"
-  default['cdap']['cdap_security']['dashboard.ssl.cert'] = "/etc/cdap/#{node['cdap']['conf_dir']}/webapp.crt"
-end
+default['cdap']['cdap_security']['security.server.ssl.keystore.password'] = 'somedefaultpassword'
+default['cdap']['cdap_security']['security.server.ssl.keystore.path'] = "/etc/cdap/#{node['cdap']['conf_dir']}/security.jks"
+default['cdap']['cdap_security']['router.ssl.keystore.password'] = 'somedefaultpassword'
+default['cdap']['cdap_security']['router.ssl.keystore.path'] = "/etc/cdap/#{node['cdap']['conf_dir']}/router.jks"
+default['cdap']['cdap_security']['dashboard.ssl.key'] = "/etc/cdap/#{node['cdap']['conf_dir']}/dashboard.key"
+default['cdap']['cdap_security']['dashboard.ssl.cert'] = "/etc/cdap/#{node['cdap']['conf_dir']}/dashboard.crt"
 
 # Auth-Server Settings
 if node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('security.enabled') &&

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -47,6 +47,30 @@ module CDAP
         end
       jks == 'JKS' ? true : false
     end
+
+    # Return hash with SSL options for JKS
+    def jks_opts(prefix)
+      ssl = {}
+      ssl['password'] = node['cdap']['cdap_security']["#{prefix}.ssl.keystore.password"]
+      ssl['keypass'] =
+        if node['cdap']['cdap_security'].key?("#{prefix}.ssl.keystore.keypassword")
+          node['cdap']['cdap_security']["#{prefix}.ssl.keystore.keypassword"]
+        else
+          ssl['password']
+        end
+      ssl['path'] = node['cdap']['cdap_security']["#{prefix}.ssl.keystore.path"]
+      ssl['common_name'] = node['cdap']['security']['ssl_common_name']
+      ssl
+    end
+
+    # Return has with SSL options for OpenSSL
+    def ssl_opts
+      ssl = {}
+      ssl['keypath'] = node['cdap']['cdap_security']['dashboard.ssl.key']
+      ssl['certpath'] = node['cdap']['cdap_security']['dashboard.ssl.cert']
+      ssl['common_name'] = node['cdap']['security']['ssl_common_name']
+      ssl
+    end
   end
 end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,45 @@
+#
+# Cookbook Name:: cdap
+# Library:: helpers
+#
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module CDAP
+  module Helpers
+    #
+    # Return true if SSL is enabled
+    #
+    def ssl_enabled?
+      ssl_enabled =
+        if node['cdap']['version'].to_f < 2.5 && node['cdap'].key?('cdap_site') &&
+           node['cdap']['cdap_site'].key?('security.server.ssl.enabled')
+          node['cdap']['cdap_site']['security.server.ssl.enabled']
+        elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled')
+          node['cdap']['cdap_site']['ssl.enabled']
+        # This one is here for compatibility, but ssl.enabled takes precedence, if set
+        elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('security.server.ssl.enabled')
+          node['cdap']['cdap_site']['security.server.ssl.enabled']
+        else
+          false
+        end
+      ssl_enabled.to_s == 'true' ? true : false
+    end
+  end
+end
+
+# Load helpers
+Chef::Recipe.send(:include, CDAP::Helpers)
+Chef::Resource.send(:include, CDAP::Helpers)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -37,6 +37,14 @@ module CDAP
         end
       ssl_enabled.to_s == 'true' ? true : false
     end
+
+    def jks?(property)
+      if node['cdap']['cdap_security'].key?(property) && node['cdap']['cdap_security'][property] == 'JKS'
+        true
+      else
+        false
+      end
+    end
   end
 end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -63,7 +63,7 @@ module CDAP
       ssl
     end
 
-    # Return has with SSL options for OpenSSL
+    # Return hash with SSL options for OpenSSL
     def ssl_opts
       ssl = {}
       ssl['keypath'] = node['cdap']['cdap_security']['dashboard.ssl.key']

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -39,11 +39,13 @@ module CDAP
     end
 
     def jks?(property)
-      if node['cdap']['cdap_security'].key?(property) && node['cdap']['cdap_security'][property] == 'JKS'
-        true
-      else
-        false
-      end
+      jks =
+        if node['cdap'].key?('cdap_security') && node['cdap']['cdap_security'].key?(property)
+          node['cdap']['cdap_security'][property]
+        else
+          'JKS'
+        end
+      jks == 'JKS' ? true : false
     end
   end
 end

--- a/recipes/gateway.rb
+++ b/recipes/gateway.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: gateway
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,20 +26,7 @@ end
 
 # Create a new keystore if SSL is enabled (and we don't already have one in place)
 execute 'create-router-ssl-keystore' do
-  ssl_enabled =
-    if node['cdap']['version'].to_f < 2.5 && node['cdap'].key?('cdap_site') &&
-       node['cdap']['cdap_site'].key?('security.server.ssl.enabled')
-      node['cdap']['cdap_site']['security.server.ssl.enabled']
-    elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled')
-      node['cdap']['cdap_site']['ssl.enabled']
-    # This one is here for compatibility, but ssl.enabled takes precedence, if set
-    elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('security.server.ssl.enabled')
-      node['cdap']['cdap_site']['security.server.ssl.enabled']
-    else
-      false
-    end
-
-  if ssl_enabled.to_s == 'true'
+  if ssl_enabled?
     password = node['cdap']['cdap_security']['router.ssl.keystore.password']
     keypass =
       if node['cdap']['cdap_security'].key?('router.ssl.keystore.keypassword')
@@ -60,7 +47,7 @@ execute 'create-router-ssl-keystore' do
 
   command "keytool -genkey -noprompt -alias ext-auth -keysize 2048 -keyalg RSA -keystore #{path} -storepass #{password} -keypass #{keypass} -dname 'CN=#{common_name}, OU=cdap, O=cdap, L=Palo Alto, ST=CA, C=US'"
   not_if { ::File.exist?(path.to_s) }
-  only_if { ssl_enabled.to_s == 'true' && jks.to_s == 'true' }
+  only_if { ssl_enabled? && jks.to_s == 'true' }
 end
 
 svcs = ['cdap-router']

--- a/recipes/gateway.rb
+++ b/recipes/gateway.rb
@@ -24,24 +24,7 @@ package 'cdap-gateway' do
   version node['cdap']['version']
 end
 
-# Create a new keystore if SSL is enabled (and we don't already have one in place)
-execute 'create-router-ssl-keystore' do
-  if ssl_enabled?
-    password = node['cdap']['cdap_security']['router.ssl.keystore.password']
-    keypass =
-      if node['cdap']['cdap_security'].key?('router.ssl.keystore.keypassword')
-        node['cdap']['cdap_security']['router.ssl.keystore.keypassword']
-      else
-        node['cdap']['cdap_security']['router.ssl.keystore.password']
-      end
-    path = node['cdap']['cdap_security']['router.ssl.keystore.path']
-    common_name = node['cdap']['security']['ssl_common_name']
-  end
-
-  command "keytool -genkey -noprompt -alias ext-auth -keysize 2048 -keyalg RSA -keystore #{path} -storepass #{password} -keypass #{keypass} -dname 'CN=#{common_name}, OU=cdap, O=cdap, L=Palo Alto, ST=CA, C=US'"
-  not_if { ::File.exist?(path.to_s) }
-  only_if { ssl_enabled? && jks?('router.ssl.keystore.type') }
-end
+include_recipe 'cdap::ssl_keystore_certificates'
 
 svcs = ['cdap-router']
 unless node['cdap']['version'].to_f >= 2.6

--- a/recipes/gateway.rb
+++ b/recipes/gateway.rb
@@ -36,18 +36,11 @@ execute 'create-router-ssl-keystore' do
       end
     path = node['cdap']['cdap_security']['router.ssl.keystore.path']
     common_name = node['cdap']['security']['ssl_common_name']
-    jks =
-      if node['cdap']['cdap_security'].key?('router.ssl.keystore.type') &&
-         node['cdap']['cdap_security']['router.ssl.keystore.type'] != 'JKS'
-        false
-      else
-        true
-      end
   end
 
   command "keytool -genkey -noprompt -alias ext-auth -keysize 2048 -keyalg RSA -keystore #{path} -storepass #{password} -keypass #{keypass} -dname 'CN=#{common_name}, OU=cdap, O=cdap, L=Palo Alto, ST=CA, C=US'"
   not_if { ::File.exist?(path.to_s) }
-  only_if { ssl_enabled? && jks.to_s == 'true' }
+  only_if { ssl_enabled? && jks?('router.ssl.keystore.type') }
 end
 
 svcs = ['cdap-router']

--- a/recipes/security.rb
+++ b/recipes/security.rb
@@ -46,18 +46,11 @@ execute 'create-security-server-ssl-keystore' do
       end
     path = node['cdap']['cdap_security']['security.server.ssl.keystore.path']
     common_name = node['cdap']['security']['ssl_common_name']
-    jks =
-      if node['cdap']['cdap_security'].key?('security.server.ssl.keystore.type') &&
-         node['cdap']['cdap_security']['security.server.ssl.keystore.type'] != 'JKS'
-        false
-      else
-        true
-      end
   end
 
   command "keytool -genkey -noprompt -alias ext-auth -keysize 2048 -keyalg RSA -keystore #{path} -storepass #{password} -keypass #{keypass} -dname 'CN=#{common_name}, OU=cdap, O=cdap, L=Palo Alto, ST=CA, C=US'"
   not_if { ::File.exist?(path.to_s) }
-  only_if { ssl_enabled? && jks.to_s == 'true' }
+  only_if { ssl_enabled? && jks?('security.server.ssl.keystore.type') }
 end
 
 # Manage Authentication realmfile

--- a/recipes/security.rb
+++ b/recipes/security.rb
@@ -25,6 +25,8 @@ package 'cdap-security' do
   version node['cdap']['version']
 end
 
+include_recipe 'cdap::ssl_keystore_certificates'
+
 template '/etc/init.d/cdap-auth-server' do
   source 'cdap-service.erb'
   mode '0755'
@@ -32,25 +34,6 @@ template '/etc/init.d/cdap-auth-server' do
   group 'root'
   action :create
   variables node['cdap']['security']
-end
-
-# Create a new keystore if SSL is enabled
-execute 'create-security-server-ssl-keystore' do
-  if ssl_enabled?
-    password = node['cdap']['cdap_security']['security.server.ssl.keystore.password']
-    keypass =
-      if node['cdap']['cdap_security'].key?('security.server.ssl.keystore.keypassword')
-        node['cdap']['cdap_security']['security.server.ssl.keystore.keypassword']
-      else
-        node['cdap']['cdap_security']['security.server.ssl.keystore.password']
-      end
-    path = node['cdap']['cdap_security']['security.server.ssl.keystore.path']
-    common_name = node['cdap']['security']['ssl_common_name']
-  end
-
-  command "keytool -genkey -noprompt -alias ext-auth -keysize 2048 -keyalg RSA -keystore #{path} -storepass #{password} -keypass #{keypass} -dname 'CN=#{common_name}, OU=cdap, O=cdap, L=Palo Alto, ST=CA, C=US'"
-  not_if { ::File.exist?(path.to_s) }
-  only_if { ssl_enabled? && jks?('security.server.ssl.keystore.type') }
 end
 
 # Manage Authentication realmfile

--- a/recipes/security.rb
+++ b/recipes/security.rb
@@ -36,20 +36,7 @@ end
 
 # Create a new keystore if SSL is enabled
 execute 'create-security-server-ssl-keystore' do
-  ssl_enabled =
-    if node['cdap']['version'].to_f < 2.5 && node['cdap'].key?('cdap_site') &&
-       node['cdap']['cdap_site'].key?('security.server.ssl.enabled')
-      node['cdap']['cdap_site']['security.server.ssl.enabled']
-    elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled')
-      node['cdap']['cdap_site']['ssl.enabled']
-    # This one is here for compatibility, but ssl.enabled takes precedence, if set
-    elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('security.server.ssl.enabled')
-      node['cdap']['cdap_site']['security.server.ssl.enabled']
-    else
-      false
-    end
-
-  if ssl_enabled.to_s == 'true'
+  if ssl_enabled?
     password = node['cdap']['cdap_security']['security.server.ssl.keystore.password']
     keypass =
       if node['cdap']['cdap_security'].key?('security.server.ssl.keystore.keypassword')
@@ -70,7 +57,7 @@ execute 'create-security-server-ssl-keystore' do
 
   command "keytool -genkey -noprompt -alias ext-auth -keysize 2048 -keyalg RSA -keystore #{path} -storepass #{password} -keypass #{keypass} -dname 'CN=#{common_name}, OU=cdap, O=cdap, L=Palo Alto, ST=CA, C=US'"
   not_if { ::File.exist?(path.to_s) }
-  only_if { ssl_enabled.to_s == 'true' && jks.to_s == 'true' }
+  only_if { ssl_enabled? && jks.to_s == 'true' }
 end
 
 # Manage Authentication realmfile

--- a/recipes/ssl_keystore_certificates.rb
+++ b/recipes/ssl_keystore_certificates.rb
@@ -1,0 +1,44 @@
+#
+# Cookbook Name:: cdap
+# Recipe:: ssl_keystore_certificates
+#
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Create Auth Server/Router Java keystores
+%w(security.server router).each do |svc|
+  execute "create-#{svc}.keystore.path-keystore" do
+    ssl = jks_opts(svc)
+    command <<-EOS
+    keytool -genkey -noprompt -alias ext-auth -keysize 2048 -keyalg RSA \
+      -keystore #{ssl['path']} -storepass #{ssl['password']} -keypass #{ssl['keypass']} \
+      -dname 'CN=#{ssl['common_name']}, OU=cdap, O=cdap, L=Palo Alto, ST=CA, C=US'
+    EOS
+    not_if { ::File.exist?(ssl['path'].to_s) }
+    only_if { ssl_enabled? && jks?("#{svc}.ssl.keystore.type") }
+  end
+end
+
+### Generate a certificate if SSL is enabled
+execute 'generate-ui-ssl-cert' do
+  ssl = ssl_opts
+  command <<-EOS
+  openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
+    -keyout #{ssl['keypath']} -out #{ssl['certpath']} \
+    -subj '/C=US/ST=CA/L=Palo Alto/OU=cdap/O=cdap/CN=#{ssl['common_name']}'
+  EOS
+  not_if { ::File.exist?(ssl['certpath']) && ::File.exist?(ssl['keypath']) }
+  only_if { ssl_enabled? }
+end

--- a/recipes/ssl_keystore_certificates.rb
+++ b/recipes/ssl_keystore_certificates.rb
@@ -20,7 +20,7 @@
 # Create Auth Server/Router Java keystores
 %w(security.server router).each do |svc|
   execute "create-#{svc}.keystore.path-keystore" do
-    ssl = jks_opts(svc)
+    ssl = jks_opts(svc) if node['cdap'].key?('cdap_security')
     command <<-EOS
     keytool -genkey -noprompt -alias ext-auth -keysize 2048 -keyalg RSA \
       -keystore #{ssl['path']} -storepass #{ssl['password']} -keypass #{ssl['keypass']} \
@@ -33,7 +33,7 @@ end
 
 ### Generate a certificate if SSL is enabled
 execute 'generate-ui-ssl-cert' do
-  ssl = ssl_opts
+  ssl = ssl_opts if node['cdap'].key?('cdap_security')
   command <<-EOS
   openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
     -keyout #{ssl['keypath']} -out #{ssl['certpath']} \

--- a/recipes/ui.rb
+++ b/recipes/ui.rb
@@ -34,6 +34,8 @@ package 'cdap-ui' do
   version node['cdap']['version']
 end
 
+include_recipe 'cdap::ssl_keystore_certificates'
+
 template '/etc/init.d/cdap-ui' do
   source 'cdap-service.erb'
   mode '0755'
@@ -41,19 +43,6 @@ template '/etc/init.d/cdap-ui' do
   group 'root'
   action :create
   variables node['cdap']['ui']
-end
-
-### Generate a certificate if SSL is enabled
-execute 'generate-ui-ssl-cert' do
-  if ssl_enabled?
-    common_name = node['cdap']['security']['ssl_common_name']
-    keypath = node['cdap']['cdap_security']['dashboard.ssl.key']
-    certpath = node['cdap']['cdap_security']['dashboard.ssl.cert']
-  end
-
-  command "openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout #{keypath} -out #{certpath} -subj '/C=US/ST=CA/L=Palo Alto/OU=cdap/O=cdap/CN=#{common_name}'"
-  not_if { File.exist?(certpath) && File.exist?(keypath) }
-  only_if { ssl_enabled? }
 end
 
 service 'cdap-ui' do

--- a/recipes/ui.rb
+++ b/recipes/ui.rb
@@ -45,17 +45,7 @@ end
 
 ### Generate a certificate if SSL is enabled
 execute 'generate-ui-ssl-cert' do
-  ssl_enabled =
-    if node['cdap']['version'].to_f < 2.5 && node['cdap'].key?('cdap_site') &&
-       node['cdap']['cdap_site'].key?('security.server.ssl.enabled')
-      node['cdap']['cdap_site']['security.server.ssl.enabled']
-    elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled')
-      node['cdap']['cdap_site']['ssl.enabled']
-    else
-      false
-    end
-
-  if ssl_enabled.to_s == 'true'
+  if ssl_enabled?
     common_name = node['cdap']['security']['ssl_common_name']
     keypath = node['cdap']['cdap_security']['dashboard.ssl.key']
     certpath = node['cdap']['cdap_security']['dashboard.ssl.cert']
@@ -63,7 +53,7 @@ execute 'generate-ui-ssl-cert' do
 
   command "openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout #{keypath} -out #{certpath} -subj '/C=US/ST=CA/L=Palo Alto/OU=cdap/O=cdap/CN=#{common_name}'"
   not_if { File.exist?(certpath) && File.exist?(keypath) }
-  only_if { ssl_enabled.to_s == 'true' }
+  only_if { ssl_enabled? }
 end
 
 service 'cdap-ui' do

--- a/recipes/web_app.rb
+++ b/recipes/web_app.rb
@@ -46,17 +46,7 @@ else
 
   ### Generate a certificate if SSL is enabled
   execute 'generate-webapp-ssl-cert' do
-    ssl_enabled =
-      if node['cdap']['version'].to_f < 2.5 && node['cdap'].key?('cdap_site') &&
-         node['cdap']['cdap_site'].key?('security.server.ssl.enabled')
-        node['cdap']['cdap_site']['security.server.ssl.enabled']
-      elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled')
-        node['cdap']['cdap_site']['ssl.enabled']
-      else
-        false
-      end
-
-    if ssl_enabled.to_s == 'true'
+    if ssl_enabled?
       common_name = node['cdap']['security']['ssl_common_name']
       keypath = node['cdap']['cdap_security']['dashboard.ssl.key']
       certpath = node['cdap']['cdap_security']['dashboard.ssl.cert']
@@ -64,7 +54,7 @@ else
 
     command "openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout #{keypath} -out #{certpath} -subj '/C=US/ST=CA/L=Palo Alto/OU=cdap/O=cdap/CN=#{common_name}'"
     not_if { ::File.exist?(certpath.to_s) && ::File.exist?(keypath.to_s) }
-    only_if { ssl_enabled.to_s == 'true' }
+    only_if { ssl_enabled? }
   end
 
   service 'cdap-web-app' do

--- a/recipes/web_app.rb
+++ b/recipes/web_app.rb
@@ -35,6 +35,8 @@ else
     version node['cdap']['version']
   end
 
+  include_recipe 'cdap::ssl_keystore_certificates'
+
   template '/etc/init.d/cdap-web-app' do
     source 'cdap-service.erb'
     mode '0755'
@@ -42,19 +44,6 @@ else
     group 'root'
     action :create
     variables node['cdap']['web_app']
-  end
-
-  ### Generate a certificate if SSL is enabled
-  execute 'generate-webapp-ssl-cert' do
-    if ssl_enabled?
-      common_name = node['cdap']['security']['ssl_common_name']
-      keypath = node['cdap']['cdap_security']['dashboard.ssl.key']
-      certpath = node['cdap']['cdap_security']['dashboard.ssl.cert']
-    end
-
-    command "openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout #{keypath} -out #{certpath} -subj '/C=US/ST=CA/L=Palo Alto/OU=cdap/O=cdap/CN=#{common_name}'"
-    not_if { ::File.exist?(certpath.to_s) && ::File.exist?(keypath.to_s) }
-    only_if { ssl_enabled? }
   end
 
   service 'cdap-web-app' do

--- a/spec/security_spec.rb
+++ b/spec/security_spec.rb
@@ -22,25 +22,8 @@ describe 'cdap::security' do
       expect(chef_run).to install_package('cdap-security')
     end
 
-    it 'does not execute create-security-server-ssl-keystore' do
-      expect(chef_run).not_to run_execute('create-security-server-ssl-keystore')
-    end
-
     it "creates #{pkg} service, but does not run it" do
       expect(chef_run).not_to start_service(pkg)
-    end
-  end
-
-  context 'with ssl.enabled' do
-    let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
-        node.automatic['domain'] = 'example.com'
-        node.override['cdap']['cdap_site']['ssl.enabled'] = true
-      end.converge(described_recipe)
-    end
-
-    it 'executes create-security-server-ssl-keystore' do
-      expect(chef_run).to run_execute('create-security-server-ssl-keystore')
     end
   end
 

--- a/spec/ssl_keystore_certificates_spec.rb
+++ b/spec/ssl_keystore_certificates_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe 'cdap::ssl_keystore_certificates' do
+  context 'with SSL disabled' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
+        node.automatic['domain'] = 'example.com'
+      end.converge(described_recipe)
+    end
+
+    %w(security.server router).each do |svc|
+      it "does not run execute[create-#{svc}.keystore.path-keystore]" do
+        expect(chef_run).not_to run_execute("create-#{svc}.keystore.path-keystore")
+      end
+    end
+
+    it 'does not run execute[generate-ui-ssl-cert]' do
+      expect(chef_run).not_to run_execute('generate-ui-ssl-cert')
+    end
+  end
+
+  context 'with SSL enabled' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
+        node.automatic['domain'] = 'example.com'
+        node.default['cdap']['cdap_site']['ssl.enabled'] = true
+        node.default['cdap']['cdap_security']['security.server.ssl.keystore.password'] = 'password'
+        node.default['cdap']['cdap_security']['security.server.ssl.keystore.path'] = '/tmp/security.jks'
+        node.default['cdap']['cdap_security']['router.ssl.keystore.password'] = 'password'
+        node.default['cdap']['cdap_security']['router.ssl.keystore.path'] = '/tmp/router.jks'
+        node.default['cdap']['cdap_security']['dashboard.ssl.cert'] = '/tmp/dashboard.cert'
+        node.default['cdap']['cdap_security']['dashboard.ssl.key'] = '/tmp/dashboard.key'
+      end.converge(described_recipe)
+    end
+
+    %w(security.server router).each do |svc|
+      it "runs execute[create-#{svc}.keystore.path-keystore]" do
+        expect(chef_run).to run_execute("create-#{svc}.keystore.path-keystore")
+      end
+    end
+
+    it 'runs execute[generate-ui-ssl-cert]' do
+      expect(chef_run).to run_execute('generate-ui-ssl-cert')
+    end
+  end
+end

--- a/spec/ui_spec.rb
+++ b/spec/ui_spec.rb
@@ -29,10 +29,6 @@ describe 'cdap::ui' do
       expect(chef_run).not_to start_service(pkg)
     end
 
-    it 'does not run execute[generate-ui-ssl-cert]' do
-      expect(chef_run).not_to run_execute('generate-ui-ssl-cert')
-    end
-
     it 'does not create /usr/bin/node link' do
       expect(chef_run).not_to create_link('/usr/bin/node').with(
         to: '/usr/local/bin/node'
@@ -57,19 +53,6 @@ describe 'cdap::ui' do
       expect(chef_run).to create_link('/usr/bin/node').with(
         to: '/usr/local/bin/node'
       )
-    end
-  end
-
-  context 'with SSL' do
-    let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
-        node.override['cdap']['cdap_site']['ssl.enabled'] = true
-        stub_command('test -e /usr/bin/node').and_return(true)
-      end.converge(described_recipe)
-    end
-
-    it 'executes generate-ui-ssl-cert' do
-      expect(chef_run).to run_execute('generate-ui-ssl-cert')
     end
   end
 end

--- a/spec/web_app_spec.rb
+++ b/spec/web_app_spec.rb
@@ -46,10 +46,6 @@ describe 'cdap::web_app' do
       expect(chef_run).not_to start_service(pkg)
     end
 
-    it 'does not run execute[generate-webapp-ssl-cert]' do
-      expect(chef_run).not_to run_execute('generate-webapp-ssl-cert')
-    end
-
     it 'does not create /usr/bin/node link' do
       expect(chef_run).not_to create_link('/usr/bin/node').with(
         to: '/usr/local/bin/node'
@@ -73,20 +69,6 @@ describe 'cdap::web_app' do
       expect(chef_run).to create_link('/usr/bin/node').with(
         to: '/usr/local/bin/node'
       )
-    end
-  end
-
-  context 'using cdap <= 2.8.0 with SSL' do
-    let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
-        node.override['cdap']['cdap_site']['ssl.enabled'] = true
-        node.override['cdap']['version'] = '2.8.0-1'
-        stub_command('test -e /usr/bin/node').and_return(true)
-      end.converge(described_recipe)
-    end
-
-    it 'executes generate-webapp-ssl-cert' do
-      expect(chef_run).to run_execute('generate-webapp-ssl-cert')
     end
   end
 end


### PR DESCRIPTION
This moves some common code into a helper library and moves all SSL generation to a single recipe, since they're all triggered by the same configuration option. Also, removed conditional around SSL options in attributes since they have no effect unless SSL is enabled in the configuration, anyway.

https://codeclimate.com/github/caskdata/cdap_cookbook/compare/feature/less-code-duplication