### PR TITLE
Disable Style/FrozenStringLiteralComment cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,5 @@ Metrics/AbcSize:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false


### PR DESCRIPTION
This is a new Ruby 2.3 feature and isn't necessary for us, so disabling. This fixes the Chef Jenkins build.