### PR TITLE
Use krb5_principal and krb5_keytab LWRPs

### DIFF
--- a/attributes/security.rb
+++ b/attributes/security.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Attribute:: security
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,13 +49,7 @@ default['cdap']['security']['realmfile'] = {}
 default['cdap']['security']['ssl_common_name'] = node['fqdn']
 
 if node['cdap']['cdap_site'].key?('kerberos.auth.enabled') && node['cdap']['cdap_site']['kerberos.auth.enabled'].to_s == 'true'
-  include_attribute 'krb5_utils'
-
-  # For keytab creation
-  default['krb5_utils']['krb5_service_keytabs']['cdap'] = { 'owner' => 'cdap', 'group' => 'cdap', 'mode' => '0640' }
-
   default_realm = node['krb5']['krb5_conf']['realms']['default_realm'].upcase
-
   # For cdap-master init script
   if node['cdap'].key?('security') && node['cdap']['security'].key?('cdap_keytab')
     default['cdap']['kerberos']['cdap_keytab'] = node['cdap']['security']['cdap_keytab']

--- a/attributes/security.rb
+++ b/attributes/security.rb
@@ -54,7 +54,7 @@ if node['cdap']['cdap_site'].key?('kerberos.auth.enabled') && node['cdap']['cdap
   if node['cdap'].key?('security') && node['cdap']['security'].key?('cdap_keytab')
     default['cdap']['kerberos']['cdap_keytab'] = node['cdap']['security']['cdap_keytab']
   else
-    default['cdap']['kerberos']['cdap_keytab'] = "#{node['krb5_utils']['keytabs_dir']}/cdap.service.keytab"
+    default['cdap']['kerberos']['cdap_keytab'] = "#{node['krb5']['keytabs_dir']}/cdap.service.keytab"
     # Backwards compat
     default['cdap']['security']['cdap_keytab'] = node['cdap']['kerberos']['cdap_keytab']
   end

--- a/metadata.json
+++ b/metadata.json
@@ -16,14 +16,14 @@
   "dependencies": {
     "ambari": ">= 0.0.0",
     "apt": ">= 0.0.0",
-    "hadoop": ">= 0.0.0",
     "java": ">= 0.0.0",
     "nodejs": ">= 0.0.0",
     "ntp": ">= 0.0.0",
     "yum": ">= 0.0.0",
     "yum-epel": ">= 0.0.0",
     "ark": "< 2.2.0",
-    "krb5_utils": ">= 0.0.0"
+    "hadoop": ">= 2.0.0",
+    "krb5": ">= 2.2.0"
   },
   "recommendations": {
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,11 +6,12 @@ description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.26.0'
 
-%w(apt ark hadoop java nodejs ntp yum yum-epel).each do |cb|
+%w(apt ark java nodejs ntp yum yum-epel).each do |cb|
   depends cb
 end
 
-depends 'krb5_utils'
+depends 'hadoop', '>= 2.0.0'
+depends 'krb5', '>= 2.2.0'
 recommends 'ambari' # ~FC053
 
 %w(amazon centos debian redhat scientific ubuntu).each do |os|

--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -57,14 +57,35 @@ end
 
 include_recipe 'krb5' if hadoop_kerberos?
 
-krb5_principal "cdap/#{node['fqdn']}" do
+princ =
+  if node['cdap']['cdap_site'].key?('cdap.master.kerberos.principal')
+    node['cdap']['cdap_site']['cdap.master.kerberos.principal']
+  else
+    "#{hdfs_user}/_HOST"
+  end
+
+# Set principal with _HOST in config, so configs match across cluster
+node.default['cdap']['cdap_site']['cdap.master.kerberos.principal'] = princ
+# Substitite _HOST with FQDN, for creating actual principals
+princ.gsub!('_HOST', node['fqdn'])
+
+krb5_principal princ do
   randkey true
   action :create
   only_if { hadoop_kerberos? }
 end
 
-krb5_keytab "#{node['krb5']['keytabs_dir']}/cdap.service.keytab" do
-  principals ["cdap/#{node['fqdn']}"]
+keytab =
+  if node['cdap']['cdap_site'].key?('cdap.master.kerberos.keytab')
+    node['cdap']['cdap_site']['cdap.master.kerberos.keytab']
+  else
+    "#{node['krb5']['keytabs_dir']}/cdap.service.keytab"
+  end
+
+node.default['cdap']['cdap_site']['cdap.master.kerberos.keytab'] = keytab
+
+krb5_keytab keytab do
+  principals [princ]
   owner 'cdap'
   group 'cdap'
   mode '0640'

--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -54,3 +54,20 @@ end
     end
   end
 end
+
+include_recipe 'krb5' if hadoop_kerberos?
+
+krb5_principal "cdap/#{node['fqdn']}" do
+  randkey true
+  action :create
+  only_if { hadoop_kerberos? }
+end
+
+krb5_keytab "#{node['krb5']['keytabs_dir']}/cdap.service.keytab" do
+  principals ["cdap/#{node['fqdn']}"]
+  owner 'cdap'
+  group 'cdap'
+  mode '0640'
+  action :create
+  only_if { hadoop_kerberos? }
+end

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -41,8 +41,7 @@ package 'cdap-master' do
 end
 
 # Include kerberos support
-if node['hadoop'].key?('core_site') && node['hadoop']['core_site'].key?('hadoop.security.authentication') &&
-   node['hadoop']['core_site']['hadoop.security.authentication'] == 'kerberos'
+if hadoop_kerberos?
 
   if node['cdap'].key?('kerberos') && node['cdap']['kerberos'].key?('cdap_keytab') &&
      node['cdap']['kerberos'].key?('cdap_principal') &&
@@ -77,12 +76,11 @@ if node['hadoop'].key?('core_site') && node['hadoop']['core_site'].key?('hadoop.
       action :modify
     end
 
-    include_recipe 'krb5_utils'
     # We need to be hbase to run our shell
     execute 'kinit-as-hbase-user' do
-      command "kinit -kt #{node['krb5_utils']['keytabs_dir']}/hbase.service.keytab hbase/#{node['fqdn']}@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
+      command "kinit -kt #{node['krb5']['keytabs_dir']}/hbase.service.keytab hbase/#{node['fqdn']}@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
       user 'hbase'
-      only_if "test -e #{node['krb5_utils']['keytabs_dir']}/hbase.service.keytab"
+      only_if "test -e #{node['krb5']['keytabs_dir']}/hbase.service.keytab"
     end
     # Template for HBase GRANT
     template "#{Chef::Config[:file_cache_path]}/hbase-grant.hbase" do


### PR DESCRIPTION
Replace usage of `krb5_utils` with LWRPs from `krb5` cookbook.
