### PR TITLE
Remove sticky bit from user JHS directories

### DIFF
--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -46,7 +46,7 @@ end
     execute "initaction-create-hdfs-mr-jhs-staging-#{dir.tr('_', '-')}-#{u}" do
       only_if "getent passwd #{u}"
       not_if "hadoop fs -test -d /tmp/hadoop-yarn/staging/history/#{dir}/#{u}", :user => u
-      command "hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/#{dir}/#{u} && hadoop fs -chown #{u} /tmp/hadoop-yarn/staging/history/#{dir}/#{u} && hadoop fs -chmod 1777 /tmp/hadoop-yarn/staging/history/#{dir}/#{u}"
+      command "hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/#{dir}/#{u} && hadoop fs -chown #{u} /tmp/hadoop-yarn/staging/history/#{dir}/#{u} && hadoop fs -chmod 770 /tmp/hadoop-yarn/staging/history/#{dir}/#{u}"
       timeout 300
       user node['cdap']['fs_superuser']
       retries 3


### PR DESCRIPTION
While the `done` and the `done_intermediate` directories need to have the sticky bit, the actual user directories under them should have more restrictive permissions and not be sticky. This allows users in the `hadoop` group to be able to operate on these files while preventing others from reading the contents.