### PR TITLE
Version bump to 2.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 cdap CHANGELOG
-===============
+==============
+
+v2.26.1 (Oct 25, 2016)
+----------------------
+- Add HDP 2.2.6.3 and 2.4.3.0 support ( Issue: #180 )
+- Remove sticky bit from user JHS directories ( Issue: #182 )
+- Honor the CDAP_USER environment ( Issue: #183 )
 
 v2.26.0 (Oct 18, 2016)
 ----------------------

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
   "recipes": {
 
   },
-  "version": "2.26.0",
+  "version": "2.26.1",
   "source_url": "https://github.com/caskdata/cdap_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10603"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.26.0'
+version          '2.26.1'
 
 %w(apt ark hadoop java nodejs ntp yum yum-epel).each do |cb|
   depends cb


### PR DESCRIPTION
Includes:
- Add HDP 2.2.6.3 and 2.4.3.0 support ( Issue: #180 )
- Remove sticky bit from user JHS directories ( Issue: #182 )
- Honor the CDAP_USER environment ( Issue: #183 )