### PR TITLE
Always run security recipe in fullstack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,18 @@ gem 'berkshelf', '~> 3.0'
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
+if RUBY_VERSION.to_f < 2.2
+  gem 'rack', '< 2.0'
+  if RUBY_VERSION.to_f < 2.1
+    gem 'fauxhai', '< 3.5'
+  else
+    gem 'fauxhai', '< 3.10'
+  end
+end
+
 if RUBY_VERSION.to_f < 2.1
   gem 'buff-ignore', '< 1.2'
   gem 'chef-zero', '< 4.6'
-  gem 'fauxhai', '< 3.5'
   gem 'ffi-yajl', '< 2.3'
   gem 'dep_selector', '< 1.0.4'
   gem 'net-http-persistent', '< 3.0'
@@ -26,7 +34,6 @@ else
   gem 'rubocop'
 end
 
-gem 'rack', '< 2.0' if RUBY_VERSION.to_f < 2.2
 gem 'ridley', '~> 4.2.0'
 gem 'faraday', '< 0.9.2'
 gem 'rainbow', '<= 1.99.1'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -69,10 +69,3 @@ if node['cdap'].key?('cdap_env') && node['cdap']['cdap_env'].key?('log_dir')
 end
 
 include_recipe 'cdap::config'
-
-if node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('security.enabled') &&
-   node['cdap']['cdap_site'].key?('security.auth.server.address') &&
-   node['cdap']['cdap_site']['security.auth.server.address'] == node['fqdn']
-
-  include_recipe 'cdap::security'
-end

--- a/recipes/fullstack.rb
+++ b/recipes/fullstack.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: fullstack
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,6 @@ include_recipe 'cdap::default'
 
 ui_recipe = node['cdap']['version'].to_i < 3 ? 'web_app' : 'ui'
 
-%W(cli gateway kafka master #{ui_recipe}).each do |recipe|
+%W(cli gateway kafka master security #{ui_recipe}).each do |recipe|
   include_recipe "cdap::#{recipe}"
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -42,18 +42,4 @@ describe 'cdap::default' do
       expect(link).to link_to('/test/logs/cdap')
     end
   end
-
-  context 'when security.enabled' do
-    let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
-        node.override['cdap']['cdap_site']['security.enabled'] = 'true'
-        stub_command(/update-alternatives --display /).and_return(false)
-        stub_command(/test -L /).and_return(false)
-      end.converge(described_recipe)
-    end
-
-    it 'includes security recipe' do
-      expect(chef_run).to include_recipe('cdap::security')
-    end
-  end
 end


### PR DESCRIPTION
Previously, we includes the `security` recipe conditional on the configuration. However, it's also quite valid to have this configuration property be empty, using CDAP's pre-defined default. Instead, always running the `security` recipe from `fullstack`, which should always install the full CDAP stack, regardless of configuration, as the default start state on services is stopped.