### PR TITLE
Do not set kafka.server.log.dirs so kafka.log.dir can be used

### DIFF
--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -27,14 +27,6 @@ default['cdap']['cdap_site']['root.namespace'] = 'cdap'
 default['cdap']['cdap_site']['hdfs.namespace'] = "/#{node['cdap']['cdap_site']['root.namespace']}"
 default['cdap']['cdap_site']['hdfs.user'] = 'yarn'
 default['cdap']['cdap_site']['kafka.seed.brokers'] = "#{node['fqdn']}:9092"
-# CDAP 3.5.0 deprecated Kafka Server settings
-if node['cdap']['version'].to_f < 3.5
-  default['cdap']['cdap_site']['kafka.log.dir'] = '/data/cdap/kafka-logs'
-  default['cdap']['cdap_site']['kafka.default.replication.factor'] = '1'
-else
-  default['cdap']['cdap_site']['kafka.server.log.dirs'] = '/data/cdap/kafka-logs'
-  default['cdap']['cdap_site']['kafka.server.default.replication.factor'] = '1'
-end
 default['cdap']['cdap_site']['log.retention.duration.days'] = '7'
 default['cdap']['cdap_site']['zookeeper.quorum'] = "#{node['fqdn']}:2181/#{node['cdap']['cdap_site']['root.namespace']}"
 default['cdap']['cdap_site']['router.bind.address'] = node['fqdn']

--- a/recipes/kafka.rb
+++ b/recipes/kafka.rb
@@ -34,7 +34,7 @@ kafka_log_dirs =
   elsif node['cdap']['cdap_site'].key?('kafka.log.dir')
     node['cdap']['cdap_site']['kafka.log.dir']
   else
-    '/tmp/kafka-logs'
+    '/data/cdap/kafka-logs'
   end
 
 node.default['cdap']['cdap_site']['kafka.server.log.dirs'] = kafka_log_dirs


### PR DESCRIPTION
Otherwise, we were setting `kafka.server.log.dirs` unconditionally, which was overriding user settings of `kafka.log.dir` with our default. Removing them simply defaults us to the CDAP default, unless the user's set it. However, in this case, we're setting the directory to an alternate location from the CDAP default, but it's the same default we had before, so the end result is no change.