### PR TITLE
Include Java in CLI recipe, unless skip is requested

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -6,6 +6,7 @@ if RUBY_VERSION.to_f < 2.0
   cookbook 'build-essential', '< 3.0'
   cookbook 'mingw', '< 1.0'
   cookbook 'ohai', '< 4.0'
+  cookbook 'yum-epel', '< 2.0'
 end
 
 metadata

--- a/Berksfile
+++ b/Berksfile
@@ -4,6 +4,7 @@ source 'https://supermarket.chef.io'
 if RUBY_VERSION.to_f < 2.0
   cookbook 'apt', '< 4.0'
   cookbook 'build-essential', '< 3.0'
+  cookbook 'mingw', '< 1.0'
   cookbook 'ohai', '< 4.0'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,39 +7,47 @@ gem 'rspec', '~> 3.0'
 
 if RUBY_VERSION.to_f < 2.2
   gem 'rack', '< 2.0'
+  # rubocop: disable Lint/UnneededDisable
+  # rubocop: disable Bundler/DuplicatedGem
   if RUBY_VERSION.to_f < 2.1
     gem 'fauxhai', '< 3.5'
   else
     gem 'fauxhai', '< 3.10'
   end
+  # rubocop: enable Bundler/DuplicatedGem
+  # rubocop: enable Lint/UnneededDisable
 end
 
 if RUBY_VERSION.to_f < 2.1
   gem 'buff-ignore', '< 1.2'
   gem 'chef-zero', '< 4.6'
-  gem 'ffi-yajl', '< 2.3'
   gem 'dep_selector', '< 1.0.4'
+  gem 'ffi-yajl', '< 2.3'
   gem 'net-http-persistent', '< 3.0'
 end
 
 if RUBY_VERSION.to_f < 2.0
+  # rubocop: disable Lint/UnneededDisable
+  # rubocop: disable Bundler/DuplicatedGem
   gem 'chef', '< 12.0'
+  gem 'foodcritic', '~> 4.0'
   gem 'json', '< 2.0'
   gem 'rubocop', '< 0.42'
   gem 'varia_model', '< 0.5.0'
-  gem 'foodcritic', '~> 4.0'
 else
   gem 'chef', '< 12.5'
   gem 'foodcritic', '~> 6.0'
   gem 'rubocop'
+  # rubocop: enable Bundler/DuplicatedGem
+  # rubocop: enable Lint/UnneededDisable
 end
 
-gem 'ridley', '~> 4.2.0'
+gem 'dep-selector-libgecode', '< 1.3.1'
 gem 'faraday', '< 0.9.2'
 gem 'rainbow', '<= 1.99.1'
-gem 'dep-selector-libgecode', '< 1.3.1'
+gem 'ridley', '~> 4.2.0'
 
 group :integration do
-  gem 'test-kitchen'
   gem 'kitchen-vagrant'
+  gem 'test-kitchen'
 end

--- a/recipes/cli.rb
+++ b/recipes/cli.rb
@@ -17,6 +17,11 @@
 # limitations under the License.
 #
 
+# Install Java, unless skip_prerequisites
+unless node['cdap'].key?('skip_prerequisites') && node['cdap']['skip_prerequisites'].to_s == 'true'
+  include_recipe 'java'
+end
+
 include_recipe 'cdap::repo'
 
 package 'cdap-cli' do


### PR DESCRIPTION
Otherwise, just using `cdap::cli` will not produce a usable CLI due to missing Java.