### PR TITLE
Support HDP 2.5.3.0

### DIFF
--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -76,6 +76,8 @@ hdp_version =
       '2.4.3.0-227'
     when '2.5.0.0'
       '2.5.0.0-1245'
+    when '2.5.3.0'
+      '2.5.3.0-37'
     else
       node['hadoop']['distribution_version']
     end


### PR DESCRIPTION
This is the latest patch release. Requires caskdata/hadoop_cookbook#311 to be merged.