### PR TITLE
Add 3.5.2 and 4.0.0 and make 4.0.0 default

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,6 +4,7 @@ source 'https://supermarket.chef.io'
 if RUBY_VERSION.to_f < 2.0
   cookbook 'apt', '< 4.0'
   cookbook 'build-essential', '< 3.0'
+  cookbook 'homebrew', '< 3.0'
   cookbook 'mingw', '< 1.0'
   cookbook 'ohai', '< 4.0'
   cookbook 'yum-epel', '< 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
 if RUBY_VERSION.to_f < 2.2
+  gem 'nio4r', '< 2.0'
   gem 'rack', '< 2.0'
   # rubocop: disable Lint/UnneededDisable
   # rubocop: disable Bundler/DuplicatedGem
@@ -24,6 +25,7 @@ if RUBY_VERSION.to_f < 2.1
   gem 'dep_selector', '< 1.0.4'
   gem 'ffi-yajl', '< 2.3'
   gem 'net-http-persistent', '< 3.0'
+  gem 'nokogiri', '< 1.7'
 end
 
 if RUBY_VERSION.to_f < 2.0

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -19,8 +19,8 @@
 
 # Default: conf.chef
 default['cdap']['conf_dir'] = 'conf.chef'
-# Default: 3.6.0-1
-default['cdap']['version'] = '3.6.0-1'
+# Default: 4.0.0-1
+default['cdap']['version'] = '4.0.0-1'
 # cdap-site.xml
 default['cdap']['cdap_site']['root.namespace'] = 'cdap'
 # ideally we could put the macro '/${cdap.namespace}' here but this attribute is used elsewhere in the cookbook

--- a/attributes/sdk.rb
+++ b/attributes/sdk.rb
@@ -79,8 +79,12 @@ default['cdap']['sdk']['checksum'] =
     '883c91073c5658a73e5603eea62bd95516521cef9ae4ed8382f724777714b24b'
   when '3.5.1'
     '9629fce59e4c413c1bf5609dd46f13a439be07becf406a69ef54374ad7763e12'
+  when '3.5.2'
+    'de2c7c319d9c850a125d3aacaddcf05c02fb2bf756033b4c43e3d1122c2cc6c4'
   when '3.6.0'
     '8b09a8f9865ff9752216d324e5d9a1c882b827677e058f3f32bb56ceac131ea0'
+  when '4.0.0'
+    '57b5733f7a2a828fe589bc89feeb7e318464e2e270b4bccd081c54981c83e859'
   end
 default['cdap']['sdk']['install_path'] = '/opt/cdap'
 default['cdap']['sdk']['user'] = 'cdap'

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -6,8 +6,8 @@ describe 'cdap::repo' do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6).converge(described_recipe)
     end
 
-    it 'adds cdap-3.6 yum repository' do
-      expect(chef_run).to add_yum_repository('cdap-3.6')
+    it 'adds cdap-4.0 yum repository' do
+      expect(chef_run).to add_yum_repository('cdap-4.0')
     end
 
     it 'deletes cask yum repository' do
@@ -44,8 +44,8 @@ describe 'cdap::repo' do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04).converge(described_recipe)
     end
 
-    it 'adds cdap-3.6 apt repository' do
-      expect(chef_run).to add_apt_repository('cdap-3.6')
+    it 'adds cdap-4.0 apt repository' do
+      expect(chef_run).to add_apt_repository('cdap-4.0')
     end
 
     it 'deletes cask apt repository' do


### PR DESCRIPTION
This adds checksums for CDAP SDK 3.5.2 and 4.0.0 and sets CDAP 4.0.0 as the default version.