### PR TITLE
Use the latest CDAP Ambari Service

### DIFF
--- a/attributes/ambari.rb
+++ b/attributes/ambari.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Attribute:: ambari
 #
-# Copyright © 2016 Cask Data, Inc.
+# Copyright © 2016-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,5 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-default['cdap']['ambari']['version'] = '3.6.0-1'
-default['cdap']['ambari']['install'] = false
+# Version of CDAP Ambari Service
+default['cdap']['ambari']['version'] = '4.0.0-1'
+# Should cdap::ambari recipe install/manage Ambari
+default['cdap']['ambari']['install_ambari'] = node['cdap']['ambari']['install'] || false

--- a/metadata.json
+++ b/metadata.json
@@ -14,6 +14,7 @@
     "ubuntu": ">= 0.0.0"
   },
   "dependencies": {
+    "ambari": ">= 0.0.0",
     "apt": ">= 0.0.0",
     "hadoop": ">= 0.0.0",
     "java": ">= 0.0.0",
@@ -25,7 +26,7 @@
     "krb5_utils": ">= 0.0.0"
   },
   "recommendations": {
-    "ambari": ">= 0.0.0"
+
   },
   "suggestions": {
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,14 +6,13 @@ description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.27.0'
 
-%w(apt hadoop java nodejs ntp yum yum-epel).each do |cb|
+%w(ambari apt hadoop java nodejs ntp yum yum-epel).each do |cb|
   depends cb
 end
 
 depends 'ark', '< 2.2.0' # Fails saying "owner" isn't a valid attribute
 
 depends 'krb5_utils'
-recommends 'ambari' # ~FC053
 
 %w(amazon centos debian redhat scientific ubuntu).each do |os|
   supports os

--- a/recipes/ambari.rb
+++ b/recipes/ambari.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: ambari
 #
-# Copyright © 2016 Cask Data, Inc.
+# Copyright © 2016-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,10 +18,10 @@
 #
 
 include_recipe 'cdap::repo'
-include_recipe 'ambari::server' if node['cdap']['ambari']['install'].to_s == 'true' # ~FC007
+include_recipe 'ambari::server' if node['cdap']['ambari']['install_ambari'].to_s == 'true'
 
 package 'cdap-ambari-service' do
   action :install
   version node['cdap']['ambari']['version']
-  notifies :restart, 'service[ambari-server]', :delayed if node['cdap']['ambari']['install'].to_s == 'true'
+  notifies :restart, 'service[ambari-server]', :delayed if node['cdap']['ambari']['install_ambari'].to_s == 'true'
 end


### PR DESCRIPTION
This uses `4.0.0-1` of the `cdap-ambari-service` and also updates the attribute controlling `ambari` cookbook usage to something a little more sane. I've also moved `ambari` into `depends` rather than the unimplemented `recommends` in the cookbook metadata.