### PR TITLE
Support source-based CDAP installs

### DIFF
--- a/attributes/source.rb
+++ b/attributes/source.rb
@@ -1,0 +1,73 @@
+#
+# Cookbook Name:: cdap
+# Attribute:: source
+#
+# Copyright © 2016-2017 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Symlink Maven
+default['maven']['setup_bin'] = true
+
+# String of Maven options to be appended to "-DskipTests=true"
+default['cdap']['source']['maven_extra_opts'] = ''
+
+# Control build behavior
+default['cdap']['source']['force_build'] = false
+default['cdap']['source']['skip_build'] = false
+default['cdap']['source']['skip_sync'] = false
+
+# Git configuration
+default['cdap']['source']['git']['local_user'] = 'root'
+default['cdap']['source']['git']['local_group'] = 'root'
+
+# CDAP Build source repository definition
+default['cdap']['source']['git']['repo']['cdap-build'] = {
+  'uri' => 'https://github.com/caskdata/cdap-build.git',
+  'branch' => 'develop',
+  'dir' => '/data/git/cdap-build',
+  'depth' => '',
+  'sync' => true,
+  'submodules' => {
+    'cdap' => {
+      'branch' => '',
+      'sync'   => true
+    },
+    'app-artifacts/cask-tracker' => {
+      'branch' => '',
+      'sync'   => true
+    },
+    'app-artifacts/cdap-navigator' => {
+      'branch' => '',
+      'sync'   => true
+    },
+    'app-artifacts/hydrator-plugins' => {
+      'branch' => '',
+      'sync'   => true
+    },
+    'security-extensions/cdap-security-extn' => {
+      'branch' => '',
+      'sync'   => true
+    }
+  }
+}
+
+# CDAP Ambari Service source repository definition
+default['cdap']['source']['git']['repo']['cdap-ambari-service'] = {
+  'uri'    => 'https://github.com/caskdata/cdap-ambari-service.git',
+  'branch' => 'develop',
+  'dir' => '/data/git/cdap-ambari-service',
+  'depth'  => '',
+  'sync'   => true
+}

--- a/files/default/logrotate-autobuild
+++ b/files/default/logrotate-autobuild
@@ -1,0 +1,8 @@
+/var/log/maven-autobuild.log {
+    rotate 7
+    daily
+    missingok
+    notifempty
+    copytruncate
+    compress
+}

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Library:: helpers
 #
-# Copyright © 2016 Cask Data, Inc.
+# Copyright © 2016-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.28.0'
 
-%w(ambari apt java nodejs ntp yum yum-epel).each do |cb|
+%w(ambari apt git java maven nodejs ntp yum yum-epel).each do |cb|
   depends cb
 end
 

--- a/recipes/_fpm.rb
+++ b/recipes/_fpm.rb
@@ -1,8 +1,8 @@
 #
 # Cookbook Name:: cdap
-# Attribute:: default
+# Recipe:: _fpm
 #
-# Copyright © 2013-2017 Cask Data, Inc.
+# Copyright © 2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,11 +17,13 @@
 # limitations under the License.
 #
 
-# Install Java and Hadoop clients by default
-default['cdap']['skip_prerequisites'] = false
+# We need fpm for all builds, and rpm-build on RPM-based distributions
+chef_gem 'fpm' do
+  action :install
+  version '1.4.0'
+end
 
-# User to run hadoop fs commands as
-default['cdap']['fs_superuser'] = 'hdfs'
-
-# Install CDAP from repository packages or source
-default['cdap']['install_method'] = 'packages'
+package 'rpm-build' do
+  action :install
+  only_if { node['platform_family'] == 'rhel' }
+end

--- a/recipes/_git.rb
+++ b/recipes/_git.rb
@@ -1,0 +1,89 @@
+#
+# Cookbook Name:: cdap
+# Recipe:: _git
+#
+# Copyright © 2015-2017 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Install git from source to ensure we're new enough on RHEL6
+include_recipe 'git::source'
+
+# User to clone repos as
+local_user =
+  if node['cdap']['source']['git']['local_user'] == 'admin'
+    'root'
+  else
+    node['cdap']['source']['git']['local_user']
+  end
+local_group = node['cdap']['source']['git']['local_group']
+
+# Clone any repositories with a branch specified and sync = true
+node['cdap']['source']['git']['repo'].each do |_repo, props|
+  # Create parent directories unconditionally
+  directory ::File.dirname(props['dir']) do
+    action :create
+    recursive true
+    owner 'root'
+    group 'root'
+    mode '1777'
+  end
+
+  next if props['branch'].nil? || props['branch'].empty? || node['cdap']['source']['skip_sync'].to_s == 'true'
+
+  git props['dir'] do # ~FC022
+    action :sync
+    revision props['branch']
+    repository props['uri']
+    enable_submodules true
+    user local_user
+    group local_group
+    depth props['depth'] unless props['depth'].to_s.empty?
+    only_if { props['sync'].to_s == 'true' }
+    notifies :write, 'log[git-notifier-autobuild]', :delayed
+  end
+
+  # Loop through any submodules, if defined
+  # - if branch.empty? update --remote; else checkout branch
+  submodules = props['submodules'] || []
+  submodules.each do |n, v|
+    # We use a bash block to ensure we use the correct git binary and options
+    bash "Run git submodule update --init --recursive --remote #{n}" do
+      action :run
+      code "/usr/local/bin/git submodule update --init --recursive --remote #{n}"
+      user local_user
+      group local_group
+      only_if { (v['branch'].empty? || v['branch'].nil?) && v['sync'].to_s == 'true' }
+      cwd props['dir']
+      notifies :write, 'log[git-notifier-autobuild]', :delayed
+    end
+    # Run an update in the submodule to whatever branch the user's specified
+    bash "Run git checkout #{v['branch']} in #{n}" do
+      action :run
+      code "/usr/local/bin/git checkout #{v['branch']}"
+      user local_user
+      group local_group
+      not_if { v['branch'].empty? || v['branch'].nil? }
+      only_if { v['sync'].to_s == 'true' }
+      cwd "#{props['dir']}/#{n}"
+      notifies :write, 'log[git-notifier-autobuild]', :delayed
+    end
+  end # End submodules
+end
+
+log 'git-notifier-autobuild' do
+  message 'CDAP: One or more Git repositories was updated...'
+  level :info
+  action :nothing
+end

--- a/recipes/_maven.rb
+++ b/recipes/_maven.rb
@@ -1,0 +1,202 @@
+#
+# Cookbook Name:: cdap_auto
+# Recipe:: _maven
+#
+# Copyright © 2015-2017 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Include build depencies
+include_recipe 'maven'
+
+repo = node['cdap']['source']['git']['repo']['cdap-build']
+local_user =
+  if node['cdap']['source']['git']['local_user'] == 'admin'
+    'root'
+  else
+    node['cdap']['source']['git']['local_user']
+  end
+local_group = node['cdap']['source']['git']['local_group']
+ver = node['cdap']['version'].to_f
+
+include_recipe 'cdap::_git'
+include_recipe 'cdap::_fpm'
+
+%w(app-artifacts security-extensions).each do |dir|
+  directory "#{repo['dir']}/#{dir}" do
+    action :create
+    owner local_user
+    group local_group
+    mode '0755'
+    only_if { ver >= 3.3 }
+  end
+end
+
+mvn_action =
+  if node['cdap']['source']['force_build']
+    :run
+  else
+    :nothing
+  end
+
+# Clean the working dir to avoid Apache RAT failures
+execute 'git-clean-fd' do
+  action mvn_action
+  command 'git clean -fd'
+  cwd repo['dir']
+  user local_user
+  group local_group
+  subscribes :run, 'log[git-notifier-autobuild]', :immediately unless node['cdap']['source']['force_build'].to_s == 'true'
+end
+
+# Install logrotate configuration for maven-autobuild.log
+cookbook_file '/etc/logrotate.d/autobuild' do
+  source 'logrotate-autobuild'
+  mode '0644'
+  action :create
+end
+
+# Remove co.cask.* from Maven cache
+bash 'maven-remove-cask-cached-artifacts' do
+  action mvn_action
+  code <<-EOH
+    set -o pipefail
+    echo "$(date) Removing previous Cask artifacts from Maven cache" | tee -a /var/log/maven-autobuild.log
+    rm -rvf ~#{local_user}/.m2/repository/co/cask/* | tee -a /var/log/maven-autobuild.log
+  EOH
+  user local_user
+  group local_group
+  subscribes :run, 'execute[git-clean-fd]', :immediately unless node['cdap']['source']['force_build'].to_s == 'true'
+end
+
+# Build/Install Apache Sentry JARs, if necessary
+sentry_cmd = 'mvn install -DskipTests -f apache-sentry'
+sentry_ver = '1.7.0'
+
+mvn_path = "#{node['maven']['m2_home']}/bin"
+
+bash 'maven-install-apache-sentry' do
+  action mvn_action
+  code <<-EOH
+    set -o pipefail
+    echo "$(date) Running: #{sentry_cmd}" | tee -a /var/log/maven-autobuild.log
+    #{sentry_cmd} | tee -a /var/log/maven-autobuild.log
+  EOH
+  cwd repo['dir']
+  user local_user
+  group local_group
+  environment('MAVEN_OPTS' => '-Xmx1024m -XX:MaxPermSize=128m',
+              'PATH' => "#{mvn_path}:/opt/chef/embedded/bin:#{ENV['PATH']}")
+  only_if "test -d #{repo['dir']}/apache-sentry"
+  not_if "test -d ~#{local_user}/.m2/repository/org/apache/sentry/sentry-provider-db/#{sentry_ver}/sentry-provider-db-#{sentry_ver}.jar"
+  subscribes :run, 'log[git-notifier-autobuild]', :immediately unless node['cdap']['source']['force_build'].to_s == 'true'
+end
+
+# Build/Install CDAP packages w/ minimal profiles, for external projects to build against
+cdap_cmd = 'mvn install -DskipTests -B -P templates -V -U'
+
+bash 'maven-install-cdap-minimal' do
+  action mvn_action
+  code <<-EOH
+    set -o pipefail
+    echo "$(date) Running: #{cdap_cmd}" | tee -a /var/log/maven-autobuild.log
+    #{cdap_cmd} | tee -a /var/log/maven-autobuild.log
+  EOH
+  cwd "#{repo['dir']}/cdap"
+  user local_user
+  group local_group
+  environment('MAVEN_OPTS' => '-Xmx4096m -XX:MaxPermSize=256m',
+              'PATH' => "#{mvn_path}:/opt/chef/embedded/bin:#{ENV['PATH']}")
+  only_if { ver >= 3.3 }
+  timeout 3600
+  subscribes :run, 'bash[maven-remove-cask-cached-artifacts]', :immediately unless node['cdap']['source']['force_build'].to_s == 'true'
+end
+
+# Configure Maven command for main CDAP build
+mvn_extra_opts = node['cdap']['source']['maven_extra_opts']
+profiles = %w(dist examples)
+case node['platform_family']
+when 'debian'
+  profiles += %w(deb-prepare deb)
+when 'rhel'
+  profiles += %w(rpm-prepare rpm)
+end
+profiles += %w(templates unit-tests) if ver >= 3.0
+
+cdap_cmd = "mvn package -DskipTests -B -P #{profiles.join(',')} -V -U #{mvn_extra_opts}"
+cdap_cmd += " -Dadditional.artifacts.dir=#{repo['dir']}/app-artifacts" if ver >= 3.3
+cdap_cmd += " -Dsecurity.extensions.dir=#{repo['dir']}/security-extensions" if ver >= 3.5
+
+# TODO: parameterize the maven build log, confirm directory existence, etc
+bash 'maven-build-cdap-packages' do
+  action mvn_action
+  code <<-EOH
+    set -o pipefail
+    echo "$(date) Running: #{cdap_cmd}" | tee -a /var/log/maven-autobuild.log
+    #{cdap_cmd} | tee -a /var/log/maven-autobuild.log
+  EOH
+  cwd repo['dir']
+  user local_user
+  group local_group
+  environment('MAVEN_OPTS' => '-Xmx4096m -XX:MaxPermSize=256m',
+              'PATH' => "#{mvn_path}:/opt/chef/embedded/bin:#{ENV['PATH']}")
+  timeout 7200
+  subscribes :run, 'log[git-notifier-autobuild]', :immediately unless node['cdap']['source']['force_build'].to_s == 'true'
+end
+
+# Explicitly install any CDAP dependencies, as we will no longer be installing from a repo
+pkg_deps =
+  if node['platform_family'] == 'debian'
+    %w(libxml2-utils)
+  elsif node['platform_family'] == 'rhel'
+    %w(libxml2)
+  else
+    []
+  end
+pkg_deps.each do |pkg|
+  package pkg do
+    action :install
+  end
+end
+
+# This block updates the package resources in this cookbook with the built from source versions
+# - identifies packages in the repository
+# - loops through packages and determines package resource name
+# - adds source attribute to package's resource
+#
+# Example: cdap/cdap-master/target/cdap-master_2.8.0-1_all.deb adds source to package[cdap-master] resource
+ruby_block 'modify-cdap-package-resources' do # ~FC014
+  block do
+    pkg_files =
+      if node['platform_family'] == 'debian'
+        ::Dir["#{repo['dir']}/cdap/*/target/cdap*.deb"]
+      elsif node['platform_family'] == 'rhel'
+        ::Dir["#{repo['dir']}/cdap/*/target/cdap*.rpm"]
+      else
+        []
+      end
+
+    pkg_files.each do |f|
+      p = f.split('/')[-3]
+      p = 'cdap' if p == 'cdap-distributions'
+      begin
+        r = resources(package: p)
+        r.source(f)
+        r.provider(Chef::Provider::Package::Dpkg) if node['platform_family'] == 'debian'
+      rescue Chef::Exceptions::ResourceNotFound
+        Chef::Log.warn("No package[#{p}] found in the resources collection... skipping")
+      end
+    end
+  end
+end

--- a/recipes/ambari.rb
+++ b/recipes/ambari.rb
@@ -17,8 +17,95 @@
 # limitations under the License.
 #
 
-include_recipe 'cdap::repo'
 include_recipe 'ambari::server' if node['cdap']['ambari']['install_ambari'].to_s == 'true'
+
+repo = node['cdap']['source']['git']['repo']['cdap-ambari-service']
+local_user =
+  if node['cdap']['source']['git']['local_user'] == 'admin'
+    'root'
+  else
+    node['cdap']['source']['git']['local_user']
+  end
+local_group = node['cdap']['source']['git']['local_group']
+
+if node['cdap']['install_method'] == 'source' && !repo['branch'].nil? && !repo['branch'].empty?
+  if node['cdap']['source']['skip_build'].to_s == 'true'
+    log 'cdap-ambari-service-skip-build' do
+      message 'CDAP: Skipping build of cdap-ambari-service from source due to skip_build == true'
+    end
+  else
+    include_recipe 'cdap::_fpm'
+    include_recipe 'cdap::_git'
+    package_formats =
+      if node['platform_family'] == 'debian'
+        'deb'
+      elsif node['platform_family'] == 'rhel'
+        'rpm'
+      end
+    run_action =
+      if node['cdap']['source']['force_build']
+        :run
+      else
+        :nothing
+      end
+    # Run the build.sh script when git resource changes or otherwise notified
+    bash 'build-cdap-ambari-service-package' do
+      action run_action
+      code <<-EOH
+        set -o pipefail
+        ./build.sh | tee -a /var/log/cdap-ambari-service-autobuild.log
+        ret=$?
+        if [[ ${ret} -ne 0 ]]; then
+          rm -rf #{repo['dir']}/var
+        fi
+        exit ${ret}
+      EOH
+      cwd repo['dir']
+      user local_user
+      group local_group
+      environment('PACKAGE_FORMATS' => package_formats,
+                  'PATH' => "/opt/chef/embedded/bin:#{ENV['PATH']}")
+      subscribes :run, "git[#{repo['dir']}]", :immediately unless node['cdap']['source']['force_build'].to_s == 'true'
+    end
+    # Emperically we have seen the initial git clone not generate a notification. This is a workaround
+    log 'build-cdap-ambari-service-trigger' do
+      message 'Triggering build for cdap-ambari-service since var is not present'
+      notifies :run, 'bash[build-cdap-ambari-service-package]', :immediately
+      not_if "test -d #{repo['dir']}/var"
+    end
+  end
+
+  # This block updates the package resource from the cdap cookbook.
+  # - identifies each package in the cdap-ambari-service repo
+  # - adds source attribute to package's resource
+  #
+  # Example: cdap-ambari-service_3.4.0-1_all.deb adds source to package[cdap-ambari-service] resource
+  ruby_block 'modify-cdap-ambari-service-package-resources' do # ~FC014
+    block do
+      pkg_files =
+        if node['platform_family'] == 'debian'
+          ::Dir["#{repo['dir']}/cdap*.deb"]
+        elsif node['platform_family'] == 'rhel'
+          ::Dir["#{repo['dir']}/cdap*.rpm"]
+        else
+          []
+        end
+
+      pkg_files.each do |f|
+        p = f.split('/')[-2]
+        begin
+          r = resources(package: p)
+          r.source(f)
+          r.provider(Chef::Provider::Package::Dpkg) if node['platform_family'] == 'debian'
+        rescue Chef::Exceptions::ResourceNotFound
+          Chef::Log.warn("No package[#{p}] found in the resources collection... skipping")
+        end
+      end
+    end
+  end
+else
+  include_recipe 'cdap::repo'
+end
 
 package 'cdap-ambari-service' do
   action :install

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: default
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,11 @@ unless node['cdap'].key?('skip_prerequisites') && node['cdap']['skip_prerequisit
   include_recipe 'cdap::prerequisites'
 end
 
-include_recipe 'cdap::repo'
+if node['cdap'].key?('install_method') && node['cdap']['install_method'] == 'source'
+  include_recipe 'cdap::_maven'
+else
+  include_recipe 'cdap::repo'
+end
 
 # add global CDAP_HOME environment variable
 file '/etc/profile.d/cdap_home.sh' do
@@ -31,11 +35,6 @@ file '/etc/profile.d/cdap_home.sh' do
     export PATH=$PATH:$CDAP_HOME/bin
   EOS
   mode '0755'
-end
-
-package 'cdap' do
-  version node['cdap']['version']
-  action :install
 end
 
 if node['cdap'].key?('cdap_env') && node['cdap']['cdap_env'].key?('log_dir')
@@ -66,6 +65,11 @@ if node['cdap'].key?('cdap_env') && node['cdap']['cdap_env'].key?('log_dir')
       to cdap_log_dir
     end
   end
+end
+
+package 'cdap' do
+  version node['cdap']['version']
+  action :install
 end
 
 include_recipe 'cdap::config'

--- a/recipes/security.rb
+++ b/recipes/security.rb
@@ -18,7 +18,7 @@
 #
 
 include_recipe 'java::default'
-include_recipe 'cdap::repo'
+include_recipe 'cdap::default'
 
 package 'cdap-security' do
   action :install

--- a/spec/security_spec.rb
+++ b/spec/security_spec.rb
@@ -6,6 +6,7 @@ describe 'cdap::security' do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
         stub_command(/update-alternatives --display /).and_return(false)
+        stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)
     end
     pkg = 'cdap-auth-server'
@@ -35,6 +36,8 @@ describe 'cdap::security' do
         node.override['cdap']['cdap_site']['security.authentication.handlerClassName'] = 'co.cask.cdap.security.server.BasicAuthenticationHandler'
         node.override['cdap']['cdap_site']['security.authentication.basic.realmfile'] = '/test/tmp/testrealm'
         node.override['cdap']['security']['realmfile']['testuser'] = 'testpass'
+        stub_command(/update-alternatives --display /).and_return(false)
+        stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)
     end
 


### PR DESCRIPTION
This supports installing CDAP from source, versus binary packages.

- [x] Uses the `cdap-build` repository, just like official CDAP release builds
- [x] Attribute-driven
  - [x] Enable using `node['cdap']['install_method']` == `source`
  - [x] Uses `node['cdap']['source']` attribute tree
  - [x] Overridable repositories
  - [x] Overridable submodule branches
- [x] Supports `ambari`, `sdk`, and all packages (via `default` recipe)
  - [x] Tested
    - [x] Distributed (`fullstack`)
    - [x] Ambari
    - [x] SDK