### PR TITLE
constrain version of base package installed with cli

### DIFF
--- a/recipes/cli.rb
+++ b/recipes/cli.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: cli
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,10 @@ end
 
 include_recipe 'cdap::repo'
 
-package 'cdap-cli' do
-  action :install
-  version node['cdap']['version']
+# Install base and cli packages. Order matters.
+%w(cdap cdap-cli).each do |pkg|
+  package pkg do
+    action :install
+    version node['cdap']['version']
+  end
 end


### PR DESCRIPTION
``cli.rb`` recipe will not constrain the version of the base ``cdap`` package installed (via package dependency of the ``cdap-cli`` package, causing [CDAP-8213](https://issues.cask.co/browse/CDAP-8213).

This simply adds a package resource to explicitly install it first.  This technically may be duplicate resource when running ``fullstack``. I can split out the "base package install" into its own recipe if anyone feels strongly, but may be overkill.