### PR TITLE
Move HBase grant commands to init

### DIFF
--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -95,3 +95,18 @@ krb5_keytab keytab do
   action :create
   only_if { hadoop_kerberos? }
 end
+
+# Template for HBase grant - this is done here to ensure it's present
+template "#{Chef::Config[:file_cache_path]}/hbase-grant.hbase" do
+  source 'hbase-shell.erb'
+  owner 'hbase'
+  group 'hadoop'
+  action :create
+end
+
+hbkt = "#{node['krb5']['keytabs_dir']}/hbase.service.keytab"
+execute 'kinit-as-hbase-and-grant' do
+  command "kinit -kt #{hbkt} hbase/#{node['fqdn']} && hbase shell #{Chef::Config[:file_cache_path]}/hbase-grant.hbase"
+  user 'hbase'
+  only_if { hadoop_kerberos? }
+end

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: master
 #
-# Copyright © 2013-2016 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -74,24 +74,6 @@ if hadoop_kerberos?
       append true
       members ['cdap']
       action :modify
-    end
-
-    # We need to be hbase to run our shell
-    execute 'kinit-as-hbase-user' do
-      command "kinit -kt #{node['krb5']['keytabs_dir']}/hbase.service.keytab hbase/#{node['fqdn']}@#{node['krb5']['krb5_conf']['realms']['default_realm'].upcase}"
-      user 'hbase'
-      only_if "test -e #{node['krb5']['keytabs_dir']}/hbase.service.keytab"
-    end
-    # Template for HBase GRANT
-    template "#{Chef::Config[:file_cache_path]}/hbase-grant.hbase" do
-      source 'hbase-shell.erb'
-      owner 'hbase'
-      group 'hadoop'
-      action :create
-    end
-    execute 'hbase-grant' do
-      command "hbase shell #{Chef::Config[:file_cache_path]}/hbase-grant.hbase"
-      user 'hbase'
     end
   else
     # Hadoop is secure, but we're not configured for Kerberos


### PR DESCRIPTION
We generally reserve commands that need external connectivity for some kind of `init` recipe. I am moving this to that recipe, so we can be sure Kerberos and HBase are already up and running prior to this code being executed.