### PR TITLE
Set Node.js version for SDK 4.0+

### DIFF
--- a/attributes/sdk.rb
+++ b/attributes/sdk.rb
@@ -102,3 +102,6 @@ default['cdap']['sdk']['init_cmd'] =
     "#{node['cdap']['sdk']['install_path']}/sdk/bin/cdap sdk"
   end
 default['cdap']['sdk']['init_actions'] = [:enable, :start]
+# Get proper Node.js version on SDK 4.0+
+default['nodejs']['install_method'] = 'binary'
+default['nodejs']['version'] = '4.5.0' if node['cdap']['version'].to_f >= 4.0


### PR DESCRIPTION
The SDK requires Node.js 4.5.0 or better and the `nodejs` cookbook installs 0.10, by default.