### PR TITLE
Switch to using Chef::VERSION for cookbook restrictions

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,13 +1,18 @@
 source 'https://supermarket.chef.io'
 
-# Restrict version due to Chef 12 requirement
-if RUBY_VERSION.to_f < 2.0
+if Chef::VERSION.to_f < 12.0
   cookbook 'apt', '< 4.0'
   cookbook 'build-essential', '< 3.0'
   cookbook 'homebrew', '< 3.0'
   cookbook 'mingw', '< 1.0'
   cookbook 'ohai', '< 4.0'
+  cookbook 'yum', '< 4.0'
   cookbook 'yum-epel', '< 2.0'
+elsif Chef::VERSION.to_f < 12.9
+  cookbook 'apt', '< 6.0'
+  cookbook 'yum', '< 5.0'
+elsif Chef::VERSION.to_f < 12.14
+  cookbook 'yum', '< 5.0'
 end
 
 metadata


### PR DESCRIPTION
The `apt` cookbook, starting with 6.0, requires Chef 12.9, which includes the `apt_repository` resource. Because of this, the test helpers aren't available on the newer cookbook versions.

For now, restricting the version of apt until we can resolve this in for both older versions and the latest version of the cookbook.