### PR TITLE
Set testing log level to error, to remove deprecation spam

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,7 @@ require 'chefspec'
 require 'chefspec/berkshelf'
 
 at_exit { ChefSpec::Coverage.report! }
+
+RSpec.configure do |config|
+  config.log_level = :error
+end


### PR DESCRIPTION
This sets the log level to error for RSpec runs.