### PR TITLE
Version bump to 2.28.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 cdap CHANGELOG
 ==============
 
+v2.28.4 (Feb 16, 2017)
+----------------------
+- Switch to using Chef::VERSION for cookbook restrictions ( Issue #207 )
+- Set testing log level to error ( Issue #208 )
+- Wrap all node attributes in version check ( Issue #209 )
+- Restrict build-essential on Chef < 12.5 ( Issue: #211 )
+
 v2.28.3 (Feb 9, 2017)
 ---------------------
 - Set Node.js version for SDK 4.0+ ( Issue #204 )

--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,7 @@
   "recipes": {
 
   },
-  "version": "2.28.3",
+  "version": "2.28.4",
   "source_url": "https://github.com/caskdata/cdap_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10603"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.28.3'
+version          '2.28.4'
 
 %w(ambari apt java nodejs ntp yum yum-epel).each do |cb|
   depends cb


### PR DESCRIPTION
This resolves Berkshelf dependency issues with certain Chef versions and fixes the Node.js installation introduced in 2.28.3