### PR TITLE
Restrict build-essential on Chef < 12.5

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -8,6 +8,10 @@ if Chef::VERSION.to_f < 12.0
   cookbook 'ohai', '< 4.0'
   cookbook 'yum', '< 4.0'
   cookbook 'yum-epel', '< 2.0'
+elsif Chef::VERSION.to_f < 12.5
+  cookbook 'apt', '< 6.0'
+  cookbook 'build-essential', '< 8.0'
+  cookbook 'yum', '< 5.0'
 elsif Chef::VERSION.to_f < 12.9
   cookbook 'apt', '< 6.0'
   cookbook 'yum', '< 5.0'


### PR DESCRIPTION
Starting with `build-essential` 8.0, the cookbook requires Chef > 12.5, so we need to set a restriction.