### PR TITLE
Update SDK 4.0.1 checksum to match released artifact

### DIFF
--- a/attributes/sdk.rb
+++ b/attributes/sdk.rb
@@ -88,7 +88,7 @@ default['cdap']['sdk']['checksum'] =
   when '4.0.0'
     '57b5733f7a2a828fe589bc89feeb7e318464e2e270b4bccd081c54981c83e859'
   when '4.0.1'
-    'df20d9d0bf21f5337f47bf92d317b5d759f0221ba69ebe0a129b0d2d965cf82f'
+    '47f01b0079132a267ec8436c5ad94470acf6285caba8be0d68732fed6b36c319'
   end
 default['cdap']['sdk']['install_path'] = '/opt/cdap'
 default['cdap']['sdk']['user'] = 'cdap'


### PR DESCRIPTION
This is a quick bug fix to the checksum for the 4.0.1 SDK ZIP file.