### PR TITLE
COOK-116 Handle deprecation of ssl.enabled

### DIFF
--- a/attributes/security.rb
+++ b/attributes/security.rb
@@ -18,19 +18,13 @@
 #
 
 # COOK-74 and COOK-116
-if node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('security.server.ssl.enabled') &&
-   !node['cdap']['cdap_site'].key?('ssl.external.enabled') &&
-   !node['cdap']['cdap_site'].key?('ssl.enabled')
-  default['cdap']['cdap_site']['ssl.enabled'] = node['cdap']['cdap_site']['security.server.ssl.enabled']
-  default['cdap']['cdap_site']['ssl.external.enabled'] = node['cdap']['cdap_site']['security.server.ssl.enabled']
-elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled') &&
-      !node['cdap']['cdap_site'].key?('security.server.ssl.enabled') &&
-      !node['cdap']['cdap_site'].key?('ssl.external.enabled')
-  default['cdap']['cdap_site']['security.server.ssl.enabled'] = node['cdap']['cdap_site']['ssl.enabled']
-  default['cdap']['cdap_site']['ssl.external.enabled'] = node['cdap']['cdap_site']['ssl.enabled']
-else
-  default['cdap']['cdap_site']['security.server.ssl.enabled'] = node['cdap']['cdap_site']['ssl.external.enabled']
-  default['cdap']['cdap_site']['ssl.enabled'] = node['cdap']['cdap_site']['ssl.external.enabled']
+ssl_props = %w(security.server.ssl.enabled ssl.enabled ssl.external.enabled)
+set_ssl_props = ssl_props & node['cdap']['cdap_site'].keys
+# check if more than one ssl property set and use the "latest"
+if set_ssl_props.length >= 1
+  ssl_props.each do |prop|
+    default['cdap']['cdap_site'][prop] = node['cdap']['cdap_site'][set_ssl_props.last]
+  end
 end
 
 # SSL Settings

--- a/attributes/security.rb
+++ b/attributes/security.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Attribute:: security
 #
-# Copyright © 2013-2016 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,20 @@
 # limitations under the License.
 #
 
-# COOK-74
+# COOK-74 and COOK-116
 if node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('security.server.ssl.enabled') &&
+   !node['cdap']['cdap_site'].key?('ssl.external.enabled') &&
    !node['cdap']['cdap_site'].key?('ssl.enabled')
   default['cdap']['cdap_site']['ssl.enabled'] = node['cdap']['cdap_site']['security.server.ssl.enabled']
+  default['cdap']['cdap_site']['ssl.external.enabled'] = node['cdap']['cdap_site']['security.server.ssl.enabled']
+elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled') &&
+      !node['cdap']['cdap_site'].key?('security.server.ssl.enabled') &&
+      !node['cdap']['cdap_site'].key?('ssl.external.enabled')
+  default['cdap']['cdap_site']['security.server.ssl.enabled'] = node['cdap']['cdap_site']['ssl.enabled']
+  default['cdap']['cdap_site']['ssl.external.enabled'] = node['cdap']['cdap_site']['ssl.enabled']
+else
+  default['cdap']['cdap_site']['security.server.ssl.enabled'] = node['cdap']['cdap_site']['ssl.external.enabled']
+  default['cdap']['cdap_site']['ssl.enabled'] = node['cdap']['cdap_site']['ssl.external.enabled']
 end
 
 # SSL Settings

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -27,9 +27,14 @@ module CDAP
         if node['cdap']['version'].to_f < 2.5 && node['cdap'].key?('cdap_site') &&
            node['cdap']['cdap_site'].key?('security.server.ssl.enabled')
           node['cdap']['cdap_site']['security.server.ssl.enabled']
+        elsif node['cdap']['version'].to_f < 4.0 && node['cdap'].key?('cdap_site') &&
+              node['cdap']['cdap_site'].key?('ssl.enabled')
+          node['cdap']['cdap_site']['ssl.enabled']
+        elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.external.enabled')
+          node['cdap']['cdap_site']['ssl.external.enabled']
+        # Now, do fallback ssl.enabled then security.server.ssl.enabled
         elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled')
           node['cdap']['cdap_site']['ssl.enabled']
-        # This one is here for compatibility, but ssl.enabled takes precedence, if set
         elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('security.server.ssl.enabled')
           node['cdap']['cdap_site']['security.server.ssl.enabled']
         else

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -9,6 +9,7 @@ describe 'cdap::config' do
         node.default['hadoop']['mapred_site']['mapreduce.framework.name'] = 'yarn'
         node.default['cdap']['cdap_site']['hdfs.user'] = 'cdap'
         node.default['cdap']['cdap_env']['log_dir'] = '/test/logs/cdap'
+        node.default['cdap']['cdap_security']['some.thing'] = 'foobar'
         stub_command(/update-alternatives --display /).and_return(false)
       end.converge(described_recipe)
     end
@@ -21,8 +22,14 @@ describe 'cdap::config' do
       expect(chef_run).to run_execute('copy logback.xml from conf.dist')
     end
 
-    it 'creates /etc/cdap/conf.chef/cdap-env.sh' do
-      expect(chef_run).to create_template('/etc/cdap/conf.chef/cdap-env.sh')
+    %w(
+      cdap-env.sh
+      cdap-security.xml
+      cdap-site.xml
+    ).each do |tmpl|
+      it "creates /etc/cdap/conf.chef/#{tmpl}" do
+        expect(chef_run).to create_template("/etc/cdap/conf.chef/#{tmpl}")
+      end
     end
 
     it 'runs execute[copy logback-container.xml from conf.dist]' do


### PR DESCRIPTION
This should basically set all of the properties that have been used for enabling external SSL. However, the library function `ssl_enabled?` will filter the list to the appropriate ones for the version of CDAP being installed. This ensures that the property used by that version of CDAP is used.