### PR TITLE
Update to CDAP 4.1.0-2 release

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -6,11 +6,13 @@ if Chef::VERSION.to_f < 12.0
   cookbook 'homebrew', '< 3.0'
   cookbook 'mingw', '< 1.0'
   cookbook 'ohai', '< 4.0'
+  cookbook 'selinux', '< 1.0'
   cookbook 'yum', '< 4.0'
   cookbook 'yum-epel', '< 2.0'
 elsif Chef::VERSION.to_f < 12.5
   cookbook 'apt', '< 6.0'
   cookbook 'build-essential', '< 8.0'
+  cookbook 'selinux', '< 1.0'
   cookbook 'yum', '< 5.0'
 elsif Chef::VERSION.to_f < 12.9
   cookbook 'apt', '< 6.0'

--- a/Berksfile
+++ b/Berksfile
@@ -12,6 +12,7 @@ if Chef::VERSION.to_f < 12.0
 elsif Chef::VERSION.to_f < 12.5
   cookbook 'apt', '< 6.0'
   cookbook 'build-essential', '< 8.0'
+  cookbook 'mingw', '< 2.0'
   cookbook 'selinux', '< 1.0'
   cookbook 'yum', '< 5.0'
 elsif Chef::VERSION.to_f < 12.9

--- a/Berksfile
+++ b/Berksfile
@@ -13,6 +13,7 @@ elsif Chef::VERSION.to_f < 12.5
   cookbook 'apt', '< 6.0'
   cookbook 'build-essential', '< 8.0'
   cookbook 'mingw', '< 2.0'
+  cookbook 'ohai', '< 5.0'
   cookbook 'selinux', '< 1.0'
   cookbook 'yum', '< 5.0'
 elsif Chef::VERSION.to_f < 12.9

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -19,8 +19,8 @@
 
 # Default: conf.chef
 default['cdap']['conf_dir'] = 'conf.chef'
-# Default: 4.0.1-1
-default['cdap']['version'] = '4.0.1-1'
+# Default: 4.1.0-2
+default['cdap']['version'] = '4.1.0-2'
 # cdap-site.xml
 default['cdap']['cdap_site']['root.namespace'] = 'cdap'
 # ideally we could put the macro '/${cdap.namespace}' here but this attribute is used elsewhere in the cookbook

--- a/attributes/sdk.rb
+++ b/attributes/sdk.rb
@@ -89,6 +89,8 @@ default['cdap']['sdk']['checksum'] =
     '57b5733f7a2a828fe589bc89feeb7e318464e2e270b4bccd081c54981c83e859'
   when '4.0.1'
     '47f01b0079132a267ec8436c5ad94470acf6285caba8be0d68732fed6b36c319'
+  when '4.1.0'
+    'a952fad174d50efef62c4b103f6d9ae0d5d0e22b378d1b5da9030de19451d0b7'
   end
 default['cdap']['sdk']['install_path'] = '/opt/cdap'
 default['cdap']['sdk']['user'] = 'cdap'

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -6,8 +6,8 @@ describe 'cdap::repo' do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6).converge(described_recipe)
     end
 
-    it 'adds cdap-4.0 yum repository' do
-      expect(chef_run).to add_yum_repository('cdap-4.0')
+    it 'adds cdap-4.1 yum repository' do
+      expect(chef_run).to add_yum_repository('cdap-4.1')
     end
 
     it 'deletes cask yum repository' do
@@ -44,8 +44,8 @@ describe 'cdap::repo' do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04).converge(described_recipe)
     end
 
-    it 'adds cdap-4.0 apt repository' do
-      expect(chef_run).to add_apt_repository('cdap-4.0')
+    it 'adds cdap-4.1 apt repository' do
+      expect(chef_run).to add_apt_repository('cdap-4.1')
     end
 
     it 'deletes cask apt repository' do


### PR DESCRIPTION
This updates the cookbook to support CDAP 4.1.0 SDK and sets the default to CDAP 4.1.0-2 for packages. This also updates the testing framework and Berksfile due to updates in upstream cookbooks.