### PR TITLE
COOK-104 Initialize Kerberos tickets before use

### DIFF
--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -17,44 +17,7 @@
 # limitations under the License.
 #
 
-# We also need the configuration, so we can run HDFS commands
-# Retries allow for orchestration scenarios where HDFS is starting up
-ns_path = node['cdap']['cdap_site']['hdfs.namespace']
-hdfs_user = node['cdap']['cdap_site']['hdfs.user']
-# Workaround for CDAP-3817, by pre-creating the transaction service snapshot directory
-tx_snapshot_dir =
-  if node['cdap']['cdap_site'].key?('data.tx.snapshot.dir')
-    node['cdap']['cdap_site']['data.tx.snapshot.dir']
-  else
-    "#{ns_path}/tx.snapshot"
-  end
-user_path = "/user/#{hdfs_user}"
-
-%W(#{ns_path} #{tx_snapshot_dir} #{user_path}).each do |path|
-  execute "initaction-create-hdfs-path#{path.tr('/', '-')}" do
-    command "hadoop fs -mkdir -p #{path} && hadoop fs -chown #{hdfs_user} #{path}"
-    not_if "hadoop fs -test -d #{path}", :user => hdfs_user
-    timeout 300
-    user node['cdap']['fs_superuser']
-    retries 3
-    retry_delay 10
-  end
-end
-
-%w(cdap yarn mapr).each do |u|
-  %w(done done_intermediate).each do |dir|
-    execute "initaction-create-hdfs-mr-jhs-staging-#{dir.tr('_', '-')}-#{u}" do
-      only_if "getent passwd #{u}"
-      not_if "hadoop fs -test -d /tmp/hadoop-yarn/staging/history/#{dir}/#{u}", :user => u
-      command "hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/#{dir}/#{u} && hadoop fs -chown #{u} /tmp/hadoop-yarn/staging/history/#{dir}/#{u} && hadoop fs -chmod 770 /tmp/hadoop-yarn/staging/history/#{dir}/#{u}"
-      timeout 300
-      user node['cdap']['fs_superuser']
-      retries 3
-      retry_delay 10
-    end
-  end
-end
-
+# Load Kerberos client and Gem, if necessary
 if hadoop_kerberos?
   include_recipe 'krb5'
   include_recipe 'krb5::rkerberos_gem'
@@ -110,4 +73,51 @@ execute 'kinit-as-hbase-and-grant' do
   command "kinit -kt #{hbkt} hbase/#{node['fqdn']} && hbase shell #{Chef::Config[:file_cache_path]}/hbase-grant.hbase"
   user 'hbase'
   only_if { hadoop_kerberos? }
+end
+
+# We also need the configuration, so we can run HDFS commands
+# Retries allow for orchestration scenarios where HDFS is starting up
+ns_path = node['cdap']['cdap_site']['hdfs.namespace']
+hdfs_user = node['cdap']['cdap_site']['hdfs.user']
+# Workaround for CDAP-3817, by pre-creating the transaction service snapshot directory
+tx_snapshot_dir =
+  if node['cdap']['cdap_site'].key?('data.tx.snapshot.dir')
+    node['cdap']['cdap_site']['data.tx.snapshot.dir']
+  else
+    "#{ns_path}/tx.snapshot"
+  end
+user_path = "/user/#{hdfs_user}"
+
+# COOK-104 - Initialize keytabs
+%W(#{hdfs_user} #{node['cdap']['fs_superuser']}).uniq.each do |kt|
+  execute "kinit-as-#{kt}" do
+    command "kinit -kt #{node['krb5']['keytabs_dir']}/#{kt}.service.keytab"
+    user kt
+    only_if { hadoop_kerberos? && ::File.exist?("#{node['krb5']['keytabs_dir']}/#{kt}.service.keytab") }
+  end
+end
+
+%W(#{ns_path} #{tx_snapshot_dir} #{user_path}).each do |path|
+  execute "initaction-create-hdfs-path#{path.tr('/', '-')}" do
+    command "hadoop fs -mkdir -p #{path} && hadoop fs -chown #{hdfs_user} #{path}"
+    not_if "hadoop fs -test -d #{path}", :user => hdfs_user
+    timeout 300
+    user node['cdap']['fs_superuser']
+    retries 3
+    retry_delay 10
+  end
+end
+
+%w(cdap yarn mapr).each do |u|
+  %w(done done_intermediate).each do |dir|
+    execute "initaction-create-hdfs-mr-jhs-staging-#{dir.tr('_', '-')}-#{u}" do
+      only_if "getent passwd #{u}"
+      not_if "hadoop fs -test -d /tmp/hadoop-yarn/staging/history/#{dir}/#{u}", :user => u
+      command "hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/#{dir}/#{u} && hadoop fs -chown #{u} /tmp/hadoop-yarn/staging/history/#{dir}/#{u} && hadoop fs -chmod 770 /tmp/hadoop-yarn/staging/history/#{dir}/#{u}"
+      timeout 300
+      user node['cdap']['fs_superuser']
+      retries 3
+      retry_delay 10
+    end
+  end
 end


### PR DESCRIPTION
There's a little less to this diff than appears. I moved the Kerberos section to the top. The only new code is lines 91-99 where we initialize the keytabs.