### PR TITLE
COOK-117 Set security.keytab.path default

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -7,6 +7,7 @@ if Chef::VERSION.to_f < 12.0
   cookbook 'mingw', '< 1.0'
   cookbook 'ohai', '< 4.0'
   cookbook 'selinux', '< 1.0'
+  cookbook 'windows', '< 2.0'
   cookbook 'yum', '< 4.0'
   cookbook 'yum-epel', '< 2.0'
 elsif Chef::VERSION.to_f < 12.5
@@ -15,6 +16,11 @@ elsif Chef::VERSION.to_f < 12.5
   cookbook 'mingw', '< 2.0'
   cookbook 'ohai', '< 5.0'
   cookbook 'selinux', '< 1.0'
+  cookbook 'windows', '< 3.0'
+  cookbook 'yum', '< 5.0'
+elsif Chef::VERSION.to_f < 12.6
+  cookbook 'apt', '< 6.0'
+  cookbook 'windows', '< 3.0'
   cookbook 'yum', '< 5.0'
 elsif Chef::VERSION.to_f < 12.9
   cookbook 'apt', '< 6.0'

--- a/attributes/security.rb
+++ b/attributes/security.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Attribute:: security
 #
-# Copyright © 2013-2016 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -104,4 +104,6 @@ if node['cdap']['cdap_site'].key?('kerberos.auth.enabled') && node['cdap']['cdap
   default['cdap']['cdap_site']['cdap.master.kerberos.keytab'] = node['cdap']['kerberos']['cdap_keytab']
   default['cdap']['cdap_site']['cdap.master.kerberos.principal'] = node['cdap']['kerberos']['cdap_principal']
 
+  # COOK-117
+  default['cdap']['cdap_site']['security.keytab.path'] = "#{node['krb5']['keytabs_dir']}/${name}.headless.keytab"
 end


### PR DESCRIPTION
Set `security.keytab.path` to a sensible default, using the defaults from the `krb5_keytab` LWRP from the `krb5` cookbook, which this cookbook uses to manage Kerberos principals and keytab files.