### PR TITLE
COOK-92 Recipe for cdap user

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Attribute:: default
 #
-# Copyright © 2013-2015 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,3 +22,10 @@ default['cdap']['skip_prerequisites'] = false
 
 # User to run hadoop fs commands as
 default['cdap']['fs_superuser'] = 'hdfs'
+
+# User information for "cdap" user (otherwise delegates to packages)
+default['cdap']['create_cdap_user'] = false
+default['cdap']['cdap_user']['username'] = 'cdap'
+default['cdap']['cdap_user']['group'] = 'cdap'
+default['cdap']['cdap_user']['uid'] = '11011'
+default['cdap']['cdap_user']['gid'] = '11011'

--- a/recipes/base.rb
+++ b/recipes/base.rb
@@ -33,6 +33,9 @@ file '/etc/profile.d/cdap_home.sh' do
   mode '0755'
 end
 
+# Create CDAP user, if configured (otherwise, delegate to package)
+include_recipe 'cdap::user' if node['cdap']['create_cdap_user'].to_s == 'true'
+
 # Install cdap base package
 package 'cdap' do
   action :install

--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -1,0 +1,33 @@
+#
+# Cookbook Name:: cdap
+# Recipe:: user
+#
+# Copyright © 2017 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Create group and user, unconditionally, unless they exist already
+group node['cdap']['cdap_user']['group'] do
+  gid node['cdap']['cdap_user']['gid']
+  action :create
+  not_if "getent group #{node['cdap']['cdap_user']['group']}"
+end
+
+user node['cdap']['cdap_user']['username'] do
+  uid node['cdap']['cdap_user']['uid']
+  gid node['cdap']['cdap_user']['gid']
+  password node['cdap']['cdap_user']['password'] if node['cdap']['cdap_user']['password']
+  not_if "getent passwd #{node['cdap']['cdap_user']['username']}"
+  action :create
+end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'cdap::base' do
+  context 'using default cdap version' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
+        node.automatic['domain'] = 'example.com'
+        stub_command(/update-alternatives --display /).and_return(false)
+        stub_command(/test -L /).and_return(false)
+      end.converge(described_recipe)
+    end
+
+    it 'creates /etc/profile.d/cdap_home.sh file' do
+      expect(chef_run).to create_file('/etc/profile.d/cdap_home.sh')
+    end
+
+    it 'installs cdap package' do
+      expect(chef_run).to install_package('cdap')
+    end
+  end
+end

--- a/spec/prerequisites_spec.rb
+++ b/spec/prerequisites_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'cdap::default' do
+describe 'cdap::prerequisites' do
   context 'using default cdap version' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
@@ -13,17 +13,8 @@ describe 'cdap::default' do
       end.converge(described_recipe)
     end
 
-    it 'creates /test/logs/cdap directory' do
-      expect(chef_run).to create_directory('/test/logs/cdap')
-    end
-
-    it 'deletes /var/log/cdap' do
-      expect(chef_run).to delete_directory('/var/log/cdap')
-    end
-
-    it 'creates /var/log/cdap symlink' do
-      link = chef_run.link('/var/log/cdap')
-      expect(link).to link_to('/test/logs/cdap')
+    it 'logs JAVA_HOME' do
+      expect(chef_run).to write_log('JAVA_HOME = /usr/lib/jvm/java')
     end
   end
 end

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'cdap::user' do
+  context 'using default cdap version' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
+        node.automatic['domain'] = 'example.com'
+        stub_command(/getent/).and_return(false)
+      end.converge(described_recipe)
+    end
+
+    it 'creates cdap group' do
+      expect(chef_run).to create_group('cdap')
+    end
+
+    it 'creates cdap user' do
+      expect(chef_run).to create_user('cdap')
+    end
+  end
+end


### PR DESCRIPTION
This creates a `cdap::user` recipe, which can be run independently of the other recipes. As such, the `user` recipe is not guarded using `node['cdap']['create_cdap_user']` so it can be included without modifying any other attributes.

- Attributes under `node['cdap']['cdap_user']` namespace
- Include `cdap::user` in base before `cdap` package installation, if configured
- Split base and prerequisites tests into their own files

Necessary Berksfile changes are in #223 to restrict `windows` cookbook.