### PR TITLE
Switch to new Ruby 1.9+ Hash syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,8 +4,6 @@ LineLength:
   Max: 600
 Documentation:
   Enabled: False
-HashSyntax:
-  Enabled: False
 Style/SpaceBeforeFirstArg:
   Enabled: false
 AsciiComments:

--- a/Rakefile
+++ b/Rakefile
@@ -51,4 +51,4 @@ rescue LoadError
 end
 
 # default tasks are quick, commit tests
-task :default => %w(foodcritic rubocop chefspec)
+task default: %w(foodcritic rubocop chefspec)

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -35,7 +35,7 @@ end
     mode sitefile == 'cdap_security' ? '0600' : '0644'
     owner 'cdap'
     group 'cdap'
-    variables :options => node['cdap'][sitefile]
+    variables options: node['cdap'][sitefile]
     action :create
   end
 end # End cdap-site.xml cdap-security.xml
@@ -47,7 +47,7 @@ if node['cdap'].key?('cdap_env')
     mode '0644'
     owner 'cdap'
     group 'cdap'
-    variables :options => node['cdap']['cdap_env']
+    variables options: node['cdap']['cdap_env']
     action :create
   end
 end # End cdap-env.sh

--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -100,7 +100,7 @@ end
 %W(#{ns_path} #{tx_snapshot_dir} #{user_path}).each do |path|
   execute "initaction-create-hdfs-path#{path.tr('/', '-')}" do
     command "hadoop fs -mkdir -p #{path} && hadoop fs -chown #{hdfs_user} #{path}"
-    not_if "hadoop fs -test -d #{path}", :user => hdfs_user
+    not_if "hadoop fs -test -d #{path}", user: hdfs_user
     timeout 300
     user node['cdap']['fs_superuser']
     retries 3
@@ -112,7 +112,7 @@ end
   %w(done done_intermediate).each do |dir|
     execute "initaction-create-hdfs-mr-jhs-staging-#{dir.tr('_', '-')}-#{u}" do
       only_if "getent passwd #{u}"
-      not_if "hadoop fs -test -d /tmp/hadoop-yarn/staging/history/#{dir}/#{u}", :user => u
+      not_if "hadoop fs -test -d /tmp/hadoop-yarn/staging/history/#{dir}/#{u}", user: u
       command "hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/#{dir}/#{u} && hadoop fs -chown #{u} /tmp/hadoop-yarn/staging/history/#{dir}/#{u} && hadoop fs -chmod 770 /tmp/hadoop-yarn/staging/history/#{dir}/#{u}"
       timeout 300
       user node['cdap']['fs_superuser']

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -47,7 +47,7 @@ if hadoop_kerberos?
      node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('kerberos.auth.enabled') &&
      node['cdap']['cdap_site']['kerberos.auth.enabled'].to_s == 'true'
 
-    my_vars = { :options => node['cdap']['kerberos'] }
+    my_vars = { options: node['cdap']['kerberos'] }
 
     directory '/etc/default' do
       owner 'root'

--- a/recipes/sdk.rb
+++ b/recipes/sdk.rb
@@ -62,7 +62,7 @@ template '/etc/profile.d/cdap-sdk.sh' do
   owner 'root'
   group 'root'
   action :create
-  variables :options => { 'path' => "${PATH}:#{node['cdap']['sdk']['install_path']}/sdk/bin" }
+  variables options: { path: "${PATH}:#{node['cdap']['sdk']['install_path']}/sdk/bin" }
 end
 
 ark 'sdk' do


### PR DESCRIPTION
This is one more cop that we have disabled that no longer needs to be, so removing the exclusion and fixing instances which fail.