### PR TITLE
Remove kstart, not necessary since CDAP-1171

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.28.5'
 
-%w(ambari ark apt java nodejs ntp yum yum-epel).each do |cb|
+%w(ambari ark apt java nodejs ntp yum).each do |cb|
   depends cb
 end
 

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -65,10 +65,6 @@ if hadoop_kerberos?
       variables my_vars
     end # End /etc/default/cdap-master
 
-    include_recipe 'yum-epel' if node['platform_family'] == 'rhel'
-
-    package 'kstart'
-
     group 'hadoop' do
       append true
       members ['cdap']
@@ -76,11 +72,11 @@ if hadoop_kerberos?
     end
   else
     # Hadoop is secure, but we're not configured for Kerberos
-    log 'bad-security-configuration' do
-      message "Invalid security configuration: You must specify node['cdap']['cdap_site']['kerberos.auth.enabled']"
+    log 'bad-kerberos-configuration' do
+      message "Invalid Kerberos configuration: You must specify node['cdap']['cdap_site']['kerberos.auth.enabled']"
       level :error
     end
-    Chef::Application.fatal!('Invalid Hadoop/CDAP security configuration')
+    Chef::Application.fatal!('Invalid Hadoop/CDAP kerberos configuration')
   end
 end
 


### PR DESCRIPTION
This hasn't been necessary since CDAP 2.7.1, but it's remained in the cookbook. This also removes the need for the `yum-epel` cookbook as a dependency, simplifying installations.