### PR TITLE
Updates to CDAP::Helpers methods

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Library:: helpers
 #
-# Copyright © 2016 Cask Data, Inc.
+# Copyright © 2016-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,32 +20,52 @@
 module CDAP
   module Helpers
     #
+    # Return true if Explore is enabled
+    #
+    def cdap_explore?
+      return true if cdap_property?('explore.enabled') &&
+                     node['cdap']['cdap_site']['explore.enabled'].to_s == 'true'
+      # Explore is enabled by default in 3.3+ (CDAP-4355)
+      return true if !cdap_property?('explore.enabled') &&
+                     node['cdap']['version'].to_f >= 3.3
+      false
+    end
+
+    #
+    # Return true if Security is enabled
+    #
+    def cdap_security?
+      return true if cdap_property?('security.enabled') &&
+                     node['cdap']['cdap_site']['security.enabled'].to_s == 'true'
+      false
+    end
+
+    #
     # Return true if SSL is enabled
     #
-    def ssl_enabled?
+    def cdap_ssl?
       ssl_enabled =
-        if node['cdap']['version'].to_f < 2.5 && node['cdap'].key?('cdap_site') &&
-           node['cdap']['cdap_site'].key?('security.server.ssl.enabled')
+        if node['cdap']['version'].to_f < 2.5 && cdap_property?('security.server.ssl.enabled')
           node['cdap']['cdap_site']['security.server.ssl.enabled']
-        elsif node['cdap']['version'].to_f < 4.0 && node['cdap'].key?('cdap_site') &&
-              node['cdap']['cdap_site'].key?('ssl.enabled')
+        elsif node['cdap']['version'].to_f < 4.0 && cdap_property?('ssl.enabled')
           node['cdap']['cdap_site']['ssl.enabled']
-        elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.external.enabled')
+        elsif cdap_property?('ssl.external.enabled')
           node['cdap']['cdap_site']['ssl.external.enabled']
         # Now, do fallback ssl.enabled then security.server.ssl.enabled
-        elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('ssl.enabled')
+        elsif cdap_property?('ssl.enabled')
           node['cdap']['cdap_site']['ssl.enabled']
-        elsif node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('security.server.ssl.enabled')
+        elsif cdap_property?('security.server.ssl.enabled')
           node['cdap']['cdap_site']['security.server.ssl.enabled']
-        else
-          false
         end
       ssl_enabled.to_s == 'true' ? true : false
     end
 
-    def jks?(property)
+    #
+    # Return true if property is configured as a Java Keystore
+    #
+    def cdap_ssl_jks?(property)
       jks =
-        if node['cdap'].key?('cdap_security') && node['cdap']['cdap_security'].key?(property)
+        if cdap_property?(property, 'cdap_security')
           node['cdap']['cdap_security'][property]
         else
           'JKS'
@@ -53,12 +73,14 @@ module CDAP
       jks == 'JKS' ? true : false
     end
 
+    #
     # Return hash with SSL options for JKS
-    def jks_opts(prefix)
+    #
+    def cdap_jks_opts(prefix)
       ssl = {}
       ssl['password'] = node['cdap']['cdap_security']["#{prefix}.ssl.keystore.password"]
       ssl['keypass'] =
-        if node['cdap']['cdap_security'].key?("#{prefix}.ssl.keystore.keypassword")
+        if cdap_property?("#{prefix}.ssl.keystore.keypassword")
           node['cdap']['cdap_security']["#{prefix}.ssl.keystore.keypassword"]
         else
           ssl['password']
@@ -68,13 +90,23 @@ module CDAP
       ssl
     end
 
+    #
     # Return hash with SSL options for OpenSSL
-    def ssl_opts
+    #
+    def cdap_ssl_opts(prefix = 'dashboard')
       ssl = {}
-      ssl['keypath'] = node['cdap']['cdap_security']['dashboard.ssl.key']
-      ssl['certpath'] = node['cdap']['cdap_security']['dashboard.ssl.cert']
+      ssl['keypath'] = node['cdap']['cdap_security']["#{prefix}.ssl.key"]
+      ssl['certpath'] = node['cdap']['cdap_security']["#{prefix}.ssl.cert"]
       ssl['common_name'] = node['cdap']['security']['ssl_common_name']
       ssl
+    end
+
+    #
+    # Return true if property is set
+    #
+    def cdap_property?(property, sitefile = 'cdap_site')
+      return true if node['cdap'].key?(sitefile) && node['cdap'][sitefile].key?(property)
+      false
     end
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,7 @@
 # Installs base package, creates log directory, and write out CDAP configuration
 include_recipe 'cdap::base'
 
-if node['cdap'].key?('cdap_env') && node['cdap']['cdap_env'].key?('log_dir')
+if cdap_property?('log_dir', 'cdap_env')
   cdap_log_dir = node['cdap']['cdap_env']['log_dir']
 
   directory cdap_log_dir do
@@ -29,7 +29,7 @@ if node['cdap'].key?('cdap_env') && node['cdap']['cdap_env'].key?('log_dir')
     mode '0755'
     action :create
     recursive true
-    only_if { node['cdap']['cdap_env'].key?('log_dir') }
+    only_if { cdap_property?('log_dir', 'cdap_env') }
   end
 
   unless cdap_log_dir == '/var/log/cdap'

--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -24,7 +24,7 @@ if hadoop_kerberos?
 end
 
 princ =
-  if node['cdap']['cdap_site'].key?('cdap.master.kerberos.principal')
+  if cdap_property?('cdap.master.kerberos.principal')
     node['cdap']['cdap_site']['cdap.master.kerberos.principal']
   else
     "#{hdfs_user}/_HOST"
@@ -42,7 +42,7 @@ krb5_principal princ do
 end
 
 keytab =
-  if node['cdap']['cdap_site'].key?('cdap.master.kerberos.keytab')
+  if cdap_property?('cdap.master.kerberos.keytab')
     node['cdap']['cdap_site']['cdap.master.kerberos.keytab']
   else
     "#{node['krb5']['keytabs_dir']}/cdap.service.keytab"
@@ -81,7 +81,7 @@ ns_path = node['cdap']['cdap_site']['hdfs.namespace']
 hdfs_user = node['cdap']['cdap_site']['hdfs.user']
 # Workaround for CDAP-3817, by pre-creating the transaction service snapshot directory
 tx_snapshot_dir =
-  if node['cdap']['cdap_site'].key?('data.tx.snapshot.dir')
+  if cdap_property?('data.tx.snapshot.dir')
     node['cdap']['cdap_site']['data.tx.snapshot.dir']
   else
     "#{ns_path}/tx.snapshot"

--- a/recipes/kafka.rb
+++ b/recipes/kafka.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: kafka
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ package 'cdap-kafka' do
   version node['cdap']['version']
 end
 
-if node['cdap']['version'].to_f >= 3.5 && node['cdap']['cdap_site'].key?('kafka.log.dir')
+if node['cdap']['version'].to_f >= 3.5 && cdap_property?('kafka.log.dir')
   Chef::Log.warn('kafka.log.dir has been deprecated. Please use kafka.server.log.dirs instead.')
 end
 

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -44,8 +44,7 @@ if hadoop_kerberos?
 
   if node['cdap'].key?('kerberos') && node['cdap']['kerberos'].key?('cdap_keytab') &&
      node['cdap']['kerberos'].key?('cdap_principal') &&
-     node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('kerberos.auth.enabled') &&
-     node['cdap']['cdap_site']['kerberos.auth.enabled'].to_s == 'true'
+     cdap_property?('kerberos.auth.enabled').to_s == 'true'
 
     directory '/etc/default' do
       owner 'root'

--- a/recipes/prerequisites.rb
+++ b/recipes/prerequisites.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: prerequisites
 #
-# Copyright © 2013-2016 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,9 +36,7 @@ end
 end
 
 # Hive is optional
-if node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('explore.enabled') &&
-   node['cdap']['cdap_site']['explore.enabled'].to_s == 'true'
-
+if cdap_explore?
   log 'hive-explore-enabled' do
     message 'Explore module enabled, installing Hive libraries'
   end

--- a/recipes/security.rb
+++ b/recipes/security.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: security
 #
-# Copyright © 2013-2016 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,9 +38,9 @@ end
 
 # Manage Authentication realmfile
 if node['cdap']['security']['manage_realmfile'].to_s == 'true' &&
-   node.key?('cdap') && node['cdap'].key?('cdap_site') && node['cdap']['cdap_site'].key?('security.authentication.handlerClassName') &&
+   cdap_property?('security.authentication.handlerClassName') &&
    node['cdap']['cdap_site']['security.authentication.handlerClassName'] == 'co.cask.cdap.security.server.BasicAuthenticationHandler' &&
-   node['cdap']['cdap_site'].key?('security.authentication.basic.realmfile')
+   cdap_property?('security.authentication.basic.realmfile')
   include_recipe 'cdap::security_realm_file'
 end
 

--- a/recipes/security_realm_file.rb
+++ b/recipes/security_realm_file.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: security_realm_file
 #
-# Copyright © 2013-2016 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 #
 
 # Manage Authentication realmfile
-if node['cdap']['cdap_site'].key?('security.authentication.basic.realmfile') && !node['cdap']['security']['realmfile'].empty?
+if cdap_property?('security.authentication.basic.realmfile') && !node['cdap']['security']['realmfile'].empty?
   realmfile = node['cdap']['cdap_site']['security.authentication.basic.realmfile']
   realmdir = ::File.dirname(realmfile)
 

--- a/recipes/ssl_keystore_certificates.rb
+++ b/recipes/ssl_keystore_certificates.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: ssl_keystore_certificates
 #
-# Copyright © 2016 Cask Data, Inc.
+# Copyright © 2016-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,25 +20,25 @@
 # Create Auth Server/Router Java keystores
 %w(security.server router).each do |svc|
   execute "create-#{svc}.keystore.path-keystore" do
-    ssl = jks_opts(svc) if node['cdap'].key?('cdap_security')
+    ssl = cdap_jks_opts(svc) if node['cdap'].key?('cdap_security')
     command <<-EOS
     keytool -genkey -noprompt -alias ext-auth -keysize 2048 -keyalg RSA \
       -keystore #{ssl['path']} -storepass #{ssl['password']} -keypass #{ssl['keypass']} \
       -dname 'CN=#{ssl['common_name']}, OU=cdap, O=cdap, L=Palo Alto, ST=CA, C=US'
     EOS
     not_if { ::File.exist?(ssl['path'].to_s) }
-    only_if { ssl_enabled? && jks?("#{svc}.ssl.keystore.type") }
+    only_if { cdap_ssl? && cdap_ssl_jks?("#{svc}.ssl.keystore.type") }
   end
 end
 
 ### Generate a certificate if SSL is enabled
 execute 'generate-ui-ssl-cert' do
-  ssl = ssl_opts if node['cdap'].key?('cdap_security')
+  ssl = cdap_ssl_opts if node['cdap'].key?('cdap_security')
   command <<-EOS
   openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
     -keyout #{ssl['keypath']} -out #{ssl['certpath']} \
     -subj '/C=US/ST=CA/L=Palo Alto/OU=cdap/O=cdap/CN=#{ssl['common_name']}'
   EOS
   not_if { ::File.exist?(ssl['certpath']) && ::File.exist?(ssl['keypath']) }
-  only_if { ssl_enabled? }
+  only_if { cdap_ssl? }
 end

--- a/spec/prerequisites_spec.rb
+++ b/spec/prerequisites_spec.rb
@@ -8,7 +8,6 @@ describe 'cdap::prerequisites' do
         node.default['hadoop']['hdfs_site']['dfs.datanode.max.transfer.threads'] = '4096'
         node.default['hadoop']['mapred_site']['mapreduce.framework.name'] = 'yarn'
         node.override['cdap']['cdap_env']['log_dir'] = '/test/logs/cdap'
-        node.default['cdap']['cdap_site']['explore.enabled'] = 'true'
         stub_command(/update-alternatives --display /).and_return(false)
         stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)
@@ -20,6 +19,23 @@ describe 'cdap::prerequisites' do
 
     it 'logs about Explore being enabled' do
       expect(chef_run).to write_log('Explore module enabled, installing Hive libraries')
+    end
+  end
+
+  context 'using CDAP 3.0' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
+        node.automatic['domain'] = 'example.com'
+        node.default['hadoop']['hdfs_site']['dfs.datanode.max.transfer.threads'] = '4096'
+        node.default['hadoop']['mapred_site']['mapreduce.framework.name'] = 'yarn'
+        node.override['cdap']['version'] = '3.0.6-1'
+        stub_command(/update-alternatives --display /).and_return(false)
+        stub_command(/test -L /).and_return(false)
+      end.converge(described_recipe)
+    end
+
+    it 'does not log about Explore being enabled' do
+      expect(chef_run).not_to write_log('Explore module enabled, installing Hive libraries')
     end
   end
 end


### PR DESCRIPTION
Updates helper methods, specifically namespacing them so they won't conflict with other method names.

- Added `cdap_explore?` and `cdap_security?` helpers
- Added `cdap_property` helper
- Rename `ssl_enabled?` to `cdap_ssl?`
- Rename `jks?` to `cdap_ssl_jks?`
- Rename `jks_opts` to `cdap_jks_opts`
- Rename `ssl_opts` to `cdap_ssl_opts` and future-proof it by allowing an optional prefix