### PR TITLE
Increase test coverage

### DIFF
--- a/spec/master_spec.rb
+++ b/spec/master_spec.rb
@@ -46,6 +46,10 @@ describe 'cdap::master' do
     it "creates #{pkg} service, but does not run it" do
       expect(chef_run).not_to start_service(pkg)
     end
+
+    it 'creates cdap-upgrade-tool resource, but does not execute it' do
+      expect(chef_run).not_to run_execute('cdap-upgrade-tool')
+    end
   end
 
   context 'using CDAP 3.0' do

--- a/spec/prerequisites_spec.rb
+++ b/spec/prerequisites_spec.rb
@@ -8,6 +8,7 @@ describe 'cdap::prerequisites' do
         node.default['hadoop']['hdfs_site']['dfs.datanode.max.transfer.threads'] = '4096'
         node.default['hadoop']['mapred_site']['mapreduce.framework.name'] = 'yarn'
         node.override['cdap']['cdap_env']['log_dir'] = '/test/logs/cdap'
+        node.default['cdap']['cdap_site']['explore.enabled'] = 'true'
         stub_command(/update-alternatives --display /).and_return(false)
         stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)
@@ -15,6 +16,10 @@ describe 'cdap::prerequisites' do
 
     it 'logs JAVA_HOME' do
       expect(chef_run).to write_log('JAVA_HOME = /usr/lib/jvm/java')
+    end
+
+    it 'logs about Explore being enabled' do
+      expect(chef_run).to write_log('Explore module enabled, installing Hive libraries')
     end
   end
 end

--- a/spec/sdk_spec.rb
+++ b/spec/sdk_spec.rb
@@ -28,6 +28,10 @@ describe 'cdap::sdk' do
       expect(chef_run).to create_template('/etc/init.d/cdap-sdk')
     end
 
+    it 'creates /etc/profile.d/cdap-sdk.sh from template' do
+      expect(chef_run).to create_template('/etc/profile.d/cdap-sdk.sh')
+    end
+
     it 'creates cdap-sdk service and starts it' do
       expect(chef_run).to start_service('cdap-sdk')
       expect(chef_run).to enable_service('cdap-sdk')


### PR DESCRIPTION
This adds coverage for the remaining items in the default configuration, except `ark` which doesn't have any sort of ChefSpec matcher.