### PR TITLE
Restrict java and update rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,8 @@ Metrics/PerceivedComplexity:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false
+Style/PercentLiteralDelimiters:
+  Enabled: false
 Style/SpaceBeforeFirstArg:
   Enabled: false
 Style/SymbolArray:

--- a/Berksfile
+++ b/Berksfile
@@ -4,6 +4,7 @@ if Chef::VERSION.to_f < 12.0
   cookbook 'apt', '< 4.0'
   cookbook 'build-essential', '< 3.0'
   cookbook 'homebrew', '< 3.0'
+  cookbook 'java', '< 1.48'
   cookbook 'mingw', '< 1.0'
   cookbook 'ohai', '< 4.0'
   cookbook 'selinux', '< 1.0'


### PR DESCRIPTION
Restrict Java cookbook as 1.48 requires Chef 12.

Older rubocop wants `( )` for %w while newer rubocop wants `[ ]` and since we cannot do both, disabling the cop. Boo.