### PR TITLE
Version bump to 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 cdap CHANGELOG
 ==============
 
+v3.0.1 (Apr 6, 2017)
+--------------------
+
+- Fix a bug with variable assignment in `init` recipe ( Issue: #235 )
+
 v3.0.0 (Apr 4, 2017)
 --------------------
 

--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,7 @@
   "recipes": {
 
   },
-  "version": "2.28.5",
+  "version": "3.0.1",
   "source_url": "https://github.com/caskdata/cdap_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10603"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.0.0'
+version          '3.0.1'
 
 %w(ambari ark apt java nodejs ntp yum).each do |cb|
   depends cb


### PR DESCRIPTION
Includes:

- Fix a bug with variable assignment in `init` recipe ( Issue: #235 )