### PR TITLE
Explicitly require 'chef/version' before using Chef::VERSION

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,7 @@
 source 'https://supermarket.chef.io'
 
+require 'chef/version'
+
 if Chef::VERSION.to_f < 12.0
   cookbook 'apt', '< 4.0'
   cookbook 'ark', '< 3.0'


### PR DESCRIPTION
Otherwise, it fails when using tools which use berkshelf but don't already initialize Chef on their own, such as... `berks`.