### PR TITLE
COOK-123 Add amazon to rhel platform_family conditional

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: repo
 #
-# Copyright © 2013-2016 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ when 'debian'
   file '/etc/apt/sources.list.d/cask.list' do
     action :delete
   end
-when 'rhel'
+when 'rhel', 'amazon' # ~FC024
   yum_repository "cdap-#{maj_min}" do
     description 'CDAP YUM repository'
     url node['cdap']['repo']['yum_repo_url']


### PR DESCRIPTION
This is needed for Chef 13 compatibility on Amazon Linux.