### PR TITLE
Version bump to 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 cdap CHANGELOG
 ==============
 
+v3.0.2 (Apr 13, 2017)
+---------------------
+
+- Update Berksfile and test Chef 13 ( Issues: #237 #239 )
+- Support platform_family amazon for Chef 13 ( Issues: #238 [COOK-123](https://issues.cask.co/browse/COOK-123) )
+- Set principal name to match keytab credentials ( Issue: #240 )
+
 v3.0.1 (Apr 6, 2017)
 --------------------
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "cdap",
   "description": "Installs/Configures Cask Data Application Platform (CDAP)",
-  "long_description": "# cdap cookbook\n\n[![Cookbook Version](http://img.shields.io/cookbook/v/cdap.svg)](https://supermarket.chef.io/cookbooks/cdap)\n[![Apache License 2.0](http://img.shields.io/badge/license-apache%202.0-green.svg)](http://opensource.org/licenses/Apache-2.0)\n[![Build Status](http://img.shields.io/travis/caskdata/cdap_cookbook.svg)](http://travis-ci.org/caskdata/cdap_cookbook)\n[![Code Climate](https://codeclimate.com/github/caskdata/cdap_cookbook/badges/gpa.svg)](https://codeclimate.com/github/caskdata/cdap_cookbook)\n[![Build Status](https://jenkins-01.eastus.cloudapp.azure.com/job/cdap-cookbook/badge/icon)](https://jenkins-01.eastus.cloudapp.azure.com/job/cdap-cookbook/)\n\n# Requirements\n\n* Oracle Java JDK 7+ with JCE (provided by `java` cookbook)\n* Hadoop 2.0+ HDFS, YARN, ZooKeeper, Hive, and HBase (provided by `hadoop` cookbook)\n\n# Usage\n\n## Distributed\n\nThe simplest usage is to install a complete CDAP stack on a single machine, using the `cdap::fullstack` recipe. Directories\nin HDFS are created using the `cdap::init` recipe. The CDAP Upgrade Tool can be run after upgrading CDAP by using the\n`cdap::upgrade` recipe.\n\n## Standalone/SDK\n\nUse the `cdap::sdk` recipe.\n\n# Attributes\n\n* `['cdap']['conf_dir']` - The directory used inside `/etc/cdap` and used via the alternatives system. Default `conf.chef`\n* `['cdap']['repo']['apt_repo_url']` - Specifies URL for fetching packages from APT\n* `['cdap']['repo']['apt_components']` - Repository components to use for APT repositories\n* `['cdap']['repo']['yum_repo_url']` - Specifies URL for fetching packages from YUM\n* `['cdap']['version']` - CDAP package version to install, must exist in the given repository\n\n# Recipes\n\n* `cli` - Installs `cdap-cli` package\n* `config` - Configures all services\n* `default` - Installs `cdap` base package and performs configuration of `cdap-site.xml`\n* `fullstack` - Installs all packages and services on a single node\n* `gateway` - Installs the `cdap-gateway` package and `cdap-gateway` and `cdap-router` services\n* `init` - Sets up HDFS, run on Master node\n* `kafka` - Installs the `cdap-kafka` package and `cdap-kafka-server` service\n* `master` - Installs the `cdap-master` package and service\n* `prerequisites` - Installs dependencies such as `hadoop`, `hbase`, `hive`, and `ntpd`\n* `repo` - Sets up package manager repositories for cdap packages\n* `sdk` - Installs the CDAP SDK and sets up a `cdap-sdk` service\n* `security` - Installs the `cdap-security` package and `cdap-auth-server` service\n* `security_realm_file` - Creates the realm file \n* `ui` - Installs the `cdap-ui` package and service, replaces `web_app`\n* `upgrade` - Executes the CDAP Upgrade Tool, run on Master node\n* `web_app` - Installs the `cdap-web-app` package and service\n\n# Author\n\nAuthor:: Cask Data, Inc. (<ops@cask.co>)\n\n# License\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this software except in compliance with the License.\nYou may obtain a copy of the License at\n\nhttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n",
+  "long_description": "# cdap cookbook\n\n[![Cookbook Version](http://img.shields.io/cookbook/v/cdap.svg)](https://supermarket.chef.io/cookbooks/cdap)\n[![Apache License 2.0](http://img.shields.io/badge/license-apache%202.0-green.svg)](http://opensource.org/licenses/Apache-2.0)\n[![Build Status](http://img.shields.io/travis/caskdata/cdap_cookbook.svg)](http://travis-ci.org/caskdata/cdap_cookbook)\n[![Code Climate](https://codeclimate.com/github/caskdata/cdap_cookbook/badges/gpa.svg)](https://codeclimate.com/github/caskdata/cdap_cookbook)\n[![Build Status](https://jenkins-01.eastus.cloudapp.azure.com/job/cdap-cookbook/badge/icon)](https://jenkins-01.eastus.cloudapp.azure.com/job/cdap-cookbook/)\n\n## Requirements\n\n* Oracle Java JDK 7+ with JCE\n* Hadoop 2.0+ HDFS, YARN, ZooKeeper, Hive, and HBase\n\n## Usage\n\n### Distributed\n\nThe simplest usage is to install a complete CDAP stack on a single machine,\nusing the `cdap::fullstack` recipe. Directories in HDFS are created using the\n`cdap::init` recipe. The CDAP Upgrade Tool can be run after upgrading CDAP by\nusing the `cdap::upgrade` recipe.\n\n### Standalone/SDK\n\nUse the `cdap::sdk` recipe.\n\n## Attributes\n\n* `['cdap']['conf_dir']` - The directory used inside `/etc/cdap` and used via the alternatives system. Default `conf.chef`\n* `['cdap']['repo']['apt_repo_url']` - Specifies URL for fetching packages from APT\n* `['cdap']['repo']['apt_components']` - Repository components to use for APT repositories\n* `['cdap']['repo']['yum_repo_url']` - Specifies URL for fetching packages from YUM\n* `['cdap']['version']` - CDAP package version to install, must exist in the given repository\n\n## Recipes\n\n* `cli` - Installs `cdap-cli` package\n* `config` - Configures all services\n* `default` - Installs `cdap` base package and performs configuration of `cdap-site.xml`\n* `fullstack` - Installs all packages and services on a single node\n* `gateway` - Installs the `cdap-gateway` package and `cdap-gateway` and `cdap-router` services\n* `init` - Sets up HDFS, run on Master node\n* `kafka` - Installs the `cdap-kafka` package and `cdap-kafka-server` service\n* `master` - Installs the `cdap-master` package and service\n* `prerequisites` - Installs dependencies such as `hadoop`, `hbase`, `hive`, and `ntpd`\n* `repo` - Sets up package manager repositories for cdap packages\n* `sdk` - Installs the CDAP SDK and sets up a `cdap-sdk` service\n* `security` - Installs the `cdap-security` package and `cdap-auth-server` service\n* `security_realm_file` - Creates the realm file \n* `ui` - Installs the `cdap-ui` package and service, replaces `web_app`\n* `upgrade` - Executes the CDAP Upgrade Tool, run on Master node\n\n## Author\n\nAuthor:: Cask Data, Inc. (<ops@cask.co>)\n\n## License\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this software except in compliance with the License.\nYou may obtain a copy of the License at\n\nhttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n",
   "maintainer": "Cask Data, Inc.",
   "maintainer_email": "ops@cask.co",
   "license": "Apache 2.0",
@@ -21,7 +21,6 @@
     "nodejs": ">= 0.0.0",
     "ntp": ">= 0.0.0",
     "yum": ">= 0.0.0",
-    "yum-epel": ">= 0.0.0",
     "hadoop": ">= 2.0.0",
     "krb5": ">= 2.2.1"
   },
@@ -49,7 +48,19 @@
   "recipes": {
 
   },
-  "version": "3.0.1",
+  "version": "3.0.2",
   "source_url": "https://github.com/caskdata/cdap_cookbook",
-  "issues_url": "https://issues.cask.co/browse/COOK/component/10603"
+  "issues_url": "https://issues.cask.co/browse/COOK/component/10603",
+  "privacy": false,
+  "chef_versions": [
+    [
+      ">= 11"
+    ]
+  ],
+  "ohai_versions": [
+
+  ],
+  "gems": [
+
+  ]
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.0.1'
+version          '3.0.2'
 
 %w(ambari ark apt java nodejs ntp yum).each do |cb|
   depends cb


### PR DESCRIPTION
Includes:

- Update Berksfile and test Chef 13 ( Issues: #237 #239 )
- Support platform_family amazon for Chef 13 ( Issues: #238 [COOK-123](https://issues.cask.co/browse/COOK-123) )
- Set principal name to match keytab credentials ( Issue: #240 )