### PR TITLE
Enforce skip_prerequisites in sdk and security recipes

### DIFF
--- a/recipes/sdk.rb
+++ b/recipes/sdk.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cdap
 # Recipe:: sdk
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,9 +18,11 @@
 #
 
 # Dependencies
-%w(ark java nodejs).each do |recipe|
+%w(ark nodejs).each do |recipe|
   include_recipe recipe
 end
+
+include_recipe 'java' unless node['cdap'].key?('skip_prerequisites') && node['cdap']['skip_prerequisites'].to_s == 'true'
 
 link '/usr/bin/node' do
   to '/usr/local/bin/node'
@@ -29,8 +31,12 @@ link '/usr/bin/node' do
 end
 
 ver = node['cdap']['version'].gsub(/-.*/, '')
-ark_prefix_path = ::File.dirname(node['cdap']['sdk']['install_path']) if ::File.basename(node['cdap']['sdk']['install_path']) == "sdk-#{ver}"
-ark_prefix_path ||= node['cdap']['sdk']['install_path']
+ark_prefix_path =
+  if ::File.basename(node['cdap']['sdk']['install_path']) == "sdk-#{ver}"
+    ::File.dirname(node['cdap']['sdk']['install_path'])
+  else
+    node['cdap']['sdk']['install_path']
+  end
 
 directory ark_prefix_path do
   action :create

--- a/recipes/security.rb
+++ b/recipes/security.rb
@@ -17,8 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'java::default'
-include_recipe 'cdap::repo'
+include_recipe 'cdap::default'
 
 package 'cdap-security' do
   action :install

--- a/spec/security_spec.rb
+++ b/spec/security_spec.rb
@@ -6,6 +6,7 @@ describe 'cdap::security' do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
         node.automatic['domain'] = 'example.com'
         stub_command(/update-alternatives --display /).and_return(false)
+        stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)
     end
     pkg = 'cdap-auth-server'
@@ -35,6 +36,8 @@ describe 'cdap::security' do
         node.override['cdap']['cdap_site']['security.authentication.handlerClassName'] = 'co.cask.cdap.security.server.BasicAuthenticationHandler'
         node.override['cdap']['cdap_site']['security.authentication.basic.realmfile'] = '/test/tmp/testrealm'
         node.override['cdap']['security']['realmfile']['testuser'] = 'testpass'
+        stub_command(/update-alternatives --display /).and_return(false)
+        stub_command(/test -L /).and_return(false)
       end.converge(described_recipe)
     end
 


### PR DESCRIPTION
This restores skipping the Java installation, which was broken in #185 