### PR TITLE
version bump for 3.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 cdap CHANGELOG
 ==============
 
+v3.1.0 (May 23, 2017)
+---------------------
+
+- Support HDP 2.5.5.0 ( Issue: #242 )
+- Remove spark.yarn.am.extraJavaOptions ( Issue: #243 )
+- Enforce skip_prerequisites in sdk and security recipes ( Issues: #244 [COOK-124](https://issues.cask.co/browse/COOK-124) )
+- Default to OpenJDK ( Issue: #245 )
+
 v3.0.2 (Apr 13, 2017)
 ---------------------
 

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
   "recipes": {
 
   },
-  "version": "3.0.2",
+  "version": "3.1.0",
   "source_url": "https://github.com/caskdata/cdap_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10603",
   "privacy": false,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.0.2'
+version          '3.1.0'
 
 %w(ambari ark apt java nodejs ntp yum).each do |cb|
   depends cb


### PR DESCRIPTION
Version bump for 3.1.0 release.

- Support HDP 2.5.5.0 ( Issue: #242 )
- Remove spark.yarn.am.extraJavaOptions ( Issue: #243 )
- Enforce skip_prerequisites in sdk and security recipes ( Issues: #244 [COOK-124](https://issues.cask.co/browse/COOK-124) )
- Default to OpenJDK ( Issue: #245 )
