### PR TITLE
version bump for 3.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 cdap CHANGELOG
 ==============
 
+v3.1.1 (May 30, 2017)
+---------------------
+
+- Fix Test Kitchen ( Issue: #247 )
+- Make /etc/profile.d/cdap-sdk.sh options configurable ( Issue: #248 )
+- Switch to HTTPS for repository.cask.co ( Issue: #249 )
+
 v3.1.0 (May 23, 2017)
 ---------------------
 

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
   "recipes": {
 
   },
-  "version": "3.1.0",
+  "version": "3.1.1",
   "source_url": "https://github.com/caskdata/cdap_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10603",
   "privacy": false,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.1.0'
+version          '3.1.1'
 
 %w(ambari ark apt java nodejs ntp yum).each do |cb|
   depends cb


### PR DESCRIPTION
Version bump for 3.1.1 release

- Fix Test Kitchen ( Issue: #247 )
- Make /etc/profile.d/cdap-sdk.sh options configurable ( Issue: #248 )
- Switch to HTTPS for repository.cask.co ( Issue: #249 )