### PR TITLE
set 4.2.0 as default, rename sdk to sandbox

### DIFF
--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -19,8 +19,8 @@
 
 # Default: conf.chef
 default['cdap']['conf_dir'] = 'conf.chef'
-# Default: 4.1.1-2
-default['cdap']['version'] = '4.1.1-2'
+# Default: 4.2.0-1
+default['cdap']['version'] = '4.2.0-1'
 # cdap-site.xml
 default['cdap']['cdap_site']['root.namespace'] = 'cdap'
 # ideally we could put the macro '/${cdap.namespace}' here but this attribute is used elsewhere in the cookbook

--- a/attributes/sdk.rb
+++ b/attributes/sdk.rb
@@ -17,8 +17,6 @@
 # limitations under the License.
 #
 
-# TODO: This cookbook has some derived attributes here. Use caution if wrapping.
-
 # URL to repository
 ver = node['cdap']['version'].gsub(/-.*/, '')
 

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -6,8 +6,8 @@ describe 'cdap::repo' do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6).converge(described_recipe)
     end
 
-    it 'adds cdap-4.1 yum repository' do
-      expect(chef_run).to add_yum_repository('cdap-4.1')
+    it 'adds cdap-4.2 yum repository' do
+      expect(chef_run).to add_yum_repository('cdap-4.2')
     end
 
     it 'deletes cask yum repository' do
@@ -37,8 +37,8 @@ describe 'cdap::repo' do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 12.04).converge(described_recipe)
     end
 
-    it 'adds cdap-4.1 apt repository' do
-      expect(chef_run).to add_apt_repository('cdap-4.1')
+    it 'adds cdap-4.2 apt repository' do
+      expect(chef_run).to add_apt_repository('cdap-4.2')
     end
 
     it 'deletes cask apt repository' do

--- a/spec/sdk_spec.rb
+++ b/spec/sdk_spec.rb
@@ -1,6 +1,37 @@
 require 'spec_helper'
 
 describe 'cdap::sdk' do
+  context 'using sdk version 4.1.0' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
+        node.automatic['domain'] = 'example.com'
+        node.override['cdap']['version'] = '4.1.0-2'
+        node.default['cdap']['sdk']['install_dir'] = '/opt/cdap'
+        stub_command('test -e /usr/bin/node').and_return(true)
+      end.converge(described_recipe)
+    end
+
+    it 'creates /etc/init.d/cdap-sdk from template' do
+      expect(chef_run).to create_template('/etc/init.d/cdap-sdk')
+    end
+
+    it 'creates /etc/profile.d/cdap-sdk.sh from template' do
+      expect(chef_run).to create_template('/etc/profile.d/cdap-sdk.sh')
+    end
+
+    it 'sets NODE_ENV in /etc/profile.d/cdap-sdk.sh' do
+      expect(chef_run).to render_file('/etc/profile.d/cdap-sdk.sh')
+        .with_content(
+          /NODE_ENV=/
+        )
+    end
+
+    it 'creates cdap-sdk service and starts it' do
+      expect(chef_run).to start_service('cdap-sdk')
+      expect(chef_run).to enable_service('cdap-sdk')
+    end
+  end
+
   context 'using default cdap version' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.6) do |node|
@@ -24,24 +55,24 @@ describe 'cdap::sdk' do
       expect(chef_run).to create_user('cdap')
     end
 
-    it 'creates /etc/init.d/cdap-sdk from template' do
-      expect(chef_run).to create_template('/etc/init.d/cdap-sdk')
+    it 'creates /etc/init.d/cdap-sandbox from template' do
+      expect(chef_run).to create_template('/etc/init.d/cdap-sandbox')
     end
 
-    it 'creates /etc/profile.d/cdap-sdk.sh from template' do
-      expect(chef_run).to create_template('/etc/profile.d/cdap-sdk.sh')
+    it 'creates /etc/profile.d/cdap-sandbox.sh from template' do
+      expect(chef_run).to create_template('/etc/profile.d/cdap-sandbox.sh')
     end
 
-    it 'sets NODE_ENV in /etc/profile.d/cdap-sdk.sh' do
-      expect(chef_run).to render_file('/etc/profile.d/cdap-sdk.sh')
+    it 'sets NODE_ENV in /etc/profile.d/cdap-sandbox.sh' do
+      expect(chef_run).to render_file('/etc/profile.d/cdap-sandbox.sh')
         .with_content(
           /NODE_ENV=/
         )
     end
 
-    it 'creates cdap-sdk service and starts it' do
-      expect(chef_run).to start_service('cdap-sdk')
-      expect(chef_run).to enable_service('cdap-sdk')
+    it 'creates cdap-sandbox service and starts it' do
+      expect(chef_run).to start_service('cdap-sandbox')
+      expect(chef_run).to enable_service('cdap-sandbox')
     end
 
     # There is no ark matcher, so we cannot test for it


### PR DESCRIPTION
- [x] sets cookbook default to CDAP ``4.2.0-1``
- [x] handle the sdk rename to sandbox. Reflect this name in the install path, init script, shell environment, etc.
- [ ] this adds some derived attributes, but in addition to some that were already there.  filed https://issues.cask.co/browse/COOK-125 to address