### PR TITLE
Version bump for 3.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 cdap CHANGELOG
 ==============
 
+v3.2.0 (Jun 12, 2017)
+---------------------
+
+- Support CDAP 4.1.1 ( Issue: #251 )
+- Set CDAP 4.2.0 as default, and rename SDK to Sandbox ( Issue: #252 )
+
 v3.1.1 (May 30, 2017)
 ---------------------
 

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
   "recipes": {
 
   },
-  "version": "3.1.1",
+  "version": "3.2.0",
   "source_url": "https://github.com/caskdata/cdap_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10603",
   "privacy": false,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.1.1'
+version          '3.2.0'
 
 %w(ambari ark apt java nodejs ntp yum).each do |cb|
   depends cb


### PR DESCRIPTION
Version bump for 3.2.0 release

- Support CDAP 4.1.1 ( Issue: #251 )
- Set CDAP 4.2.0 as default, and rename SDK to Sandbox ( Issue: #252 )
