### PR TITLE
add ability to disable checksum enforcing

### DIFF
--- a/attributes/sdk.rb
+++ b/attributes/sdk.rb
@@ -36,6 +36,8 @@ default['cdap']['sdk']['product_name'] =
     'sandbox'
   end
 
+# Enforce checksum matching by default
+default['cdap']['sdk']['enforce_checksum'] = true
 # shasum -a 256 filename
 default['cdap']['sdk']['checksum'] =
   case ver

--- a/recipes/sdk.rb
+++ b/recipes/sdk.rb
@@ -76,7 +76,7 @@ ark 'sdk' do
   url node['cdap']['sdk']['url']
   prefix_root ark_prefix_path
   prefix_home ark_prefix_path
-  checksum node['cdap']['sdk']['checksum']
+  checksum node['cdap']['sdk']['checksum'] if node['cdap']['sdk']['enforce_checksum'].to_s == 'true'
   version ver
   owner node['cdap']['sdk']['user']
   group node['cdap']['sdk']['user']


### PR DESCRIPTION
add the ability to disable checksum enforcing.  This gives us the option to disable it in our builds, rather than rely on the versions being updated in a timely manner.