### PR TITLE
Version bump for 3.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 cdap CHANGELOG
 ==============
 
+v3.2.1 (Jun 26, 2017)
+---------------------
+
+- Ability to disable checksum enforcing ( Issue: #254 )
+- Support HDP 2.6.1.0 ( Issue: #255 )
+
 v3.2.0 (Jun 12, 2017)
 ---------------------
 

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
   "recipes": {
 
   },
-  "version": "3.2.0",
+  "version": "3.2.1",
   "source_url": "https://github.com/caskdata/cdap_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10603",
   "privacy": false,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.2.0'
+version          '3.2.1'
 
 %w(ambari ark apt java nodejs ntp yum).each do |cb|
   depends cb


### PR DESCRIPTION
Version bump for 3.2.1 release.

- Ability to disable checksum enforcing ( Issue: #254 )
- Support HDP 2.6.1.0 ( Issue: #255 )