### PR TITLE
override distribution repo for debian releases

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -10,6 +10,7 @@ if Chef::VERSION.to_f < 12.0
   cookbook 'homebrew', '< 3.0'
   cookbook 'java', '< 1.48'
   cookbook 'mingw', '< 1.0'
+  cookbook 'nodejs', '< 4.0'
   cookbook 'ohai', '< 4.0'
   cookbook 'selinux', '< 1.0'
   cookbook 'windows', '< 2.0'

--- a/Berksfile
+++ b/Berksfile
@@ -13,6 +13,7 @@ if Chef::VERSION.to_f < 12.0
   cookbook 'nodejs', '< 4.0'
   cookbook 'ohai', '< 4.0'
   cookbook 'selinux', '< 1.0'
+  cookbook 'sysctl', '< 0.10'
   cookbook 'windows', '< 2.0'
   cookbook 'yum', '< 4.0'
   cookbook 'yum-epel', '< 2.0'
@@ -24,6 +25,7 @@ elsif Chef::VERSION.to_f < 12.5
   cookbook 'mingw', '< 2.0'
   cookbook 'ohai', '< 5.0'
   cookbook 'selinux', '< 1.0'
+  cookbook 'sysctl', '< 0.10'
   cookbook 'windows', '< 3.0'
   cookbook 'yum', '< 5.0'
 elsif Chef::VERSION.to_f < 12.6

--- a/Gemfile
+++ b/Gemfile
@@ -5,47 +5,60 @@ gem 'berkshelf', '~> 3.0'
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
-if RUBY_VERSION.to_f < 2.2
-  gem 'ffi-yajl', '< 2.3'
-  gem 'nio4r', '< 2.0'
-  gem 'rack', '< 2.0'
-  # rubocop: disable Lint/UnneededDisable
-  # rubocop: disable Bundler/DuplicatedGem
-  if RUBY_VERSION.to_f < 2.1
-    gem 'fauxhai', '< 3.5'
-  else
-    gem 'fauxhai', '< 3.10'
-  end
-  # rubocop: enable Bundler/DuplicatedGem
-  # rubocop: enable Lint/UnneededDisable
-end
-
-if RUBY_VERSION.to_f < 2.1
-  gem 'buff-ignore', '< 1.2'
-  gem 'chef-zero', '< 4.6'
-  gem 'dep_selector', '< 1.0.4'
-  gem 'net-http-persistent', '< 3.0'
-  gem 'nokogiri', '< 1.7'
-end
+# rubocop: disable Lint/UnneededDisable
+# rubocop: disable Bundler/DuplicatedGem
 
 if RUBY_VERSION.to_f < 2.0
-  # rubocop: disable Lint/UnneededDisable
-  # rubocop: disable Bundler/DuplicatedGem
+  gem 'buff-ignore', '< 1.2'
   gem 'chef', '< 12.0'
+  gem 'chef-zero', '< 4.6'
+  gem 'dep_selector', '< 1.0.4'
+  gem 'fauxhai', '< 3.5'
+  gem 'ffi-yajl', '< 2.3'
   gem 'foodcritic', '~> 4.0'
   gem 'json', '< 2.0'
+  gem 'mixlib-shellout', '< 2.3.0'
+  gem 'net-http-persistent', '< 3.0'
+  gem 'nio4r', '< 2.0'
+  gem 'nokogiri', '< 1.7'
+  gem 'rack', '< 2.0'
   gem 'rubocop', '< 0.42'
   gem 'varia_model', '< 0.5.0'
-elsif RUBY_VERSION.to_f > 2.3
-  gem 'chef'
-  gem 'foodcritic'
+elsif RUBY_VERSION.to_f == 2.0
+  gem 'buff-ignore', '< 1.2'
+  gem 'chef', '< 12.5'
+  gem 'chef-zero', '< 4.6'
+  gem 'dep_selector', '< 1.0.4'
+  gem 'fauxhai', '< 3.5'
+  gem 'ffi-yajl', '< 2.3'
+  gem 'foodcritic', '~> 6.0'
+  gem 'mixlib-shellout', '< 2.3.0'
+  gem 'net-http-persistent', '< 3.0'
+  gem 'nio4r', '< 2.0'
+  gem 'nokogiri', '< 1.7'
+  gem 'rack', '< 2.0'
   gem 'rubocop'
-else
+elsif RUBY_VERSION.to_f == 2.1
+  gem 'chef', '< 12.5'
+  gem 'fauxhai', '< 3.10'
+  gem 'ffi-yajl', '< 2.3.1'
+  gem 'foodcritic', '~> 6.0'
+  gem 'mixlib-shellout', '< 2.3.0'
+  gem 'nio4r', '< 2.0'
+  gem 'rack', '< 2.0'
+  gem 'rubocop'
+elsif RUBY_VERSION.to_f == 2.2
   gem 'chef', '< 12.5'
   gem 'foodcritic', '~> 6.0'
   gem 'rubocop'
-  # rubocop: enable Bundler/DuplicatedGem
-  # rubocop: enable Lint/UnneededDisable
+elsif RUBY_VERSION.to_f == 2.3
+  gem 'chef', '< 12.5'
+  gem 'foodcritic', '~> 6.0'
+  gem 'rubocop'
+else
+  gem 'chef'
+  gem 'foodcritic'
+  gem 'rubocop'
 end
 
 gem 'dep-selector-libgecode', '< 1.3.1'

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -24,7 +24,7 @@ when 'debian'
   include_recipe 'apt'
   codename = node['lsb']['codename']
   case codename
-  when 'raring', 'saucy', 'trusty', 'utopic', 'vivid', 'wily', 'xenial'
+  when 'raring', 'saucy', 'trusty', 'utopic', 'vivid', 'wily', 'xenial', 'wheezy', 'jessie', 'stretch'
     codename = 'precise'
     Chef::Log.warn('Overriding repository distribution to Precise')
   end


### PR DESCRIPTION
use the single cdap .deb repo for debian releases, otherwise package installs fail.  This is kinda ugly, but continues to be our only option until https://issues.cask.co/browse/CDAP-7832 is resolved.