### PR TITLE
add support for hdp 2.6.4.0

### DIFF
--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -88,6 +88,8 @@ hdp_version =
       '2.6.2.0-205'
     when '2.6.3.0'
       '2.6.3.0-235'
+    when '2.6.4.0'
+      '2.6.4.0-91'
     else
       node['hadoop']['distribution_version']
     end


### PR DESCRIPTION
add support for hdp 2.6.4

```
$ curl -s http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.4.0/build.id | grep BUILD_NUMBER
BUILD_NUMBER: 91
```
