### PR TITLE
update rubocop gem

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -14,6 +14,7 @@ if Chef::VERSION.to_f < 12.0
   cookbook 'ohai', '< 4.0'
   cookbook 'selinux', '< 1.0'
   cookbook 'sysctl', '< 0.10'
+  cookbook 'ulimit', '< 1.0.0'
   cookbook 'windows', '< 2.0'
   cookbook 'yum', '< 4.0'
   cookbook 'yum-epel', '< 2.0'
@@ -27,18 +28,22 @@ elsif Chef::VERSION.to_f < 12.5
   cookbook 'ohai', '< 5.0'
   cookbook 'selinux', '< 1.0'
   cookbook 'sysctl', '< 0.10'
+  cookbook 'ulimit', '< 1.0.0'
   cookbook 'windows', '< 3.0'
   cookbook 'yum', '< 5.0'
 elsif Chef::VERSION.to_f < 12.6
   cookbook 'apt', '< 6.0'
   cookbook 'nodejs', '< 5.0'
+  cookbook 'ulimit', '< 1.0.0'
   cookbook 'windows', '< 3.0'
   cookbook 'yum', '< 5.0'
 elsif Chef::VERSION.to_f < 12.9
   cookbook 'apt', '< 6.0'
   cookbook 'nodejs', '< 5.0'
+  cookbook 'ulimit', '< 1.0.0'
   cookbook 'yum', '< 5.0'
 elsif Chef::VERSION.to_f < 12.14
+  cookbook 'ulimit', '< 1.0.0'
   cookbook 'yum', '< 5.0'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ if RUBY_VERSION.to_f < 2.0
   gem 'mixlib-shellout', '< 2.3.0'
   gem 'net-http-persistent', '< 3.0'
   gem 'nio4r', '< 2.0'
-  gem 'nokogiri', '< 1.7'
+  gem 'nokogiri'
   gem 'rack', '< 2.0'
   gem 'rubocop'
   gem 'varia_model', '< 0.5.0'
@@ -35,7 +35,7 @@ elsif RUBY_VERSION.to_f == 2.0
   gem 'mixlib-shellout', '< 2.3.0'
   gem 'net-http-persistent', '< 3.0'
   gem 'nio4r', '< 2.0'
-  gem 'nokogiri', '< 1.7'
+  gem 'nokogiri'
   gem 'rack', '< 2.0'
   gem 'rubocop'
 elsif RUBY_VERSION.to_f == 2.1

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ if RUBY_VERSION.to_f < 2.0
   gem 'nio4r', '< 2.0'
   gem 'nokogiri', '< 1.7'
   gem 'rack', '< 2.0'
-  gem 'rubocop', '< 0.42'
+  gem 'rubocop'
   gem 'varia_model', '< 0.5.0'
 elsif RUBY_VERSION.to_f == 2.0
   gem 'buff-ignore', '< 1.2'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,6 +12,7 @@ end
 
 depends 'hadoop', '>= 2.0.0'
 depends 'krb5', '>= 2.2.1'
+depends 'ulimit', '< 1.0.0'
 
 %w(amazon centos debian redhat scientific ubuntu).each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,6 @@ end
 
 depends 'hadoop', '>= 2.0.0'
 depends 'krb5', '>= 2.2.1'
-depends 'ulimit', '< 1.0.0'
 
 %w(amazon centos debian redhat scientific ubuntu).each do |os|
   supports os


### PR DESCRIPTION
- [x] restrict the ulimit cookbook to < 1.0.0
https://github.com/bmhatfield/chef-ulimit/blob/master/CHANGELOG.md#100

- [x]  update the default Rubocop gem version
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418

- [x]  update Nokigiri gem
http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-9050