### PR TITLE
version bump for 3.3.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 cdap CHANGELOG
 ==============
 
+v3.3.3 (Mar 27, 2018)
+---------------------
+- Update rubocop gem ( Issue #271 )
+- Support CDAP 4.3.4 ( Issue #272 )
+
 v3.3.2 (Jan 15, 2018)
 ---------------------
 

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
   "recipes": {
 
   },
-  "version": "3.3.2",
+  "version": "3.3.3",
   "source_url": "https://github.com/caskdata/cdap_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10603",
   "privacy": false,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.3.2'
+version          '3.3.3'
 
 %w(ambari ark apt java nodejs ntp yum).each do |cb|
   depends cb


### PR DESCRIPTION
includes:

- Update rubocop gem ( Issue #271 )
- Support CDAP 4.3.4 ( Issue #272 )