### PR TITLE
Feature/12907 update jvm opts

### DIFF
--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -42,14 +42,24 @@ if node.key?('hadoop') && node['hadoop'].key?('distribution') && node['hadoop'].
   if node['hadoop']['distribution'] == 'hdp' && node['hadoop']['distribution_version'].to_f >= 2.2 &&
      node['cdap']['version'].to_f >= 3.1
     default['cdap']['cdap_env']['opts'] = '${OPTS} -Dhdp.version=%<_FULL_VERSION>s'
-    default['cdap']['cdap_site']['app.program.jvm.opts'] = '-XX:MaxPermSize=128M ${twill.jvm.gc.opts} -Dhdp.version=%<_FULL_VERSION>s'
+    default['cdap']['cdap_site']['app.program.jvm.opts'] =
+      if node['java']['jdk_version'].to_i < 8
+        '-XX:MaxPermSize=128M ${twill.jvm.gc.opts} -Dhdp.version=%<_FULL_VERSION>s'
+      else
+        '${twill.jvm.gc.opts} -Dhdp.version=%<_FULL_VERSION>s'
+      end
     if node['cdap']['version'].to_f < 3.4
       default['cdap']['cdap_env']['spark_home'] = '/usr/hdp/%<_FULL_VERSION>s/spark'
     end
   elsif node['hadoop']['distribution'] == 'iop'
     iop_version = node['hadoop']['distribution_version']
     default['cdap']['cdap_env']['opts'] = "${OPTS} -Diop.version=#{iop_version}"
-    default['cdap']['cdap_site']['app.program.jvm.opts'] = "-XX:MaxPermSize=128M ${twill.jvm.gc.opts} -Diop.version=#{iop_version}"
+    default['cdap']['cdap_site']['app.program.jvm.opts'] =
+      if node['java']['jdk_version'].to_i < 8
+        "-XX:MaxPermSize=128M ${twill.jvm.gc.opts} -Diop.version=#{iop_version}"
+      else
+        "${twill.jvm.gc.opts} -Diop.version=#{iop_version}"
+      end
   elsif node['cdap']['version'].to_f < 3.4 # CDAP 3.4 determines SPARK_HOME on its own (CDAP-5086)
     default['cdap']['cdap_env']['spark_home'] = '/usr/lib/spark'
   end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -57,7 +57,7 @@ module CDAP
         elsif cdap_property?('security.server.ssl.enabled')
           node['cdap']['cdap_site']['security.server.ssl.enabled']
         end
-      ssl_enabled.to_s == 'true' ? true : false
+      ssl_enabled.to_s == 'true'
     end
 
     #
@@ -70,7 +70,7 @@ module CDAP
         else
           'JKS'
         end
-      jks == 'JKS' ? true : false
+      jks == 'JKS'
     end
 
     #

--- a/recipes/sdk.rb
+++ b/recipes/sdk.rb
@@ -72,8 +72,7 @@ template "/etc/profile.d/cdap-#{node['cdap']['sdk']['product_name']}.sh" do
   variables options: node['cdap']['sdk']['profile_d']
 end
 
-ark 'sdk' do
-  name node['cdap']['sdk']['product_name']
+ark node['cdap']['sdk']['product_name'] do
   url node['cdap']['sdk']['url']
   prefix_root ark_prefix_path
   prefix_home ark_prefix_path

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -1,4 +1,3 @@
-#
 
 describe directory('/opt/cdap') do
   it { should exist }


### PR DESCRIPTION
- [x] don't set `-XX:MaxPermSize=128M` if on JDK < 8.
   - this was only being set to match the default in `cdap-default.xml`, which has been updated in https://github.com/caskdata/cdap/pull/10124
- [x] style updates to pass Travis