### PR TITLE
Version bump for 3.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 cdap CHANGELOG
 ==============
 
+v3.5.0 (Aug 3, 2018)
+--------------------
+- Set only JDK-version appropriate JVM options ( Issue: #278 )
+- Support CDAP 5.0.0 ( Issue #279 )
+
 v3.4.0 (May 4, 2018)
 --------------------
 - Use Hadoop cookbook's helper library to evaluate HDP build number instead of maintaining our own ( Issue: #274 )

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
   "recipes": {
 
   },
-  "version": "3.4.0",
+  "version": "3.5.0",
   "source_url": "https://github.com/caskdata/cdap_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10603",
   "privacy": false,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache-2.0'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.4.0'
+version          '3.5.0'
 
 %w(ambari ark apt java nodejs ntp yum).each do |cb|
   depends cb


### PR DESCRIPTION
- Set only JDK-version appropriate JVM options ( Issue: #278 )
- Support CDAP 5.0.0 ( Issue #279 )