### PR TITLE
update nodeJS default version for CDAP 5.0

### DIFF
--- a/attributes/sdk.rb
+++ b/attributes/sdk.rb
@@ -138,9 +138,15 @@ default['cdap']['sdk']['init_cmd'] =
     "#{node['cdap']['sdk']['install_path']}/#{node['cdap']['sdk']['product_name']}/bin/cdap sandbox"
   end
 default['cdap']['sdk']['init_actions'] = [:enable, :start]
-# Get proper Node.js version on SDK 4.0+
-if node['cdap']['version'].to_f >= 4.0
+# Get proper Node.js version on SDK 4.x
+if node['cdap']['version'].to_f >= 4.0 && node['cdap']['version'].to_f < 5.0
   default['nodejs']['install_method'] = 'binary'
   default['nodejs']['version'] = '4.5.0'
+  default['nodejs']['binary']['checksum']['linux_x64'] = nil
+end
+# Get proper Node.js version on SDK 5.0+
+if node['cdap']['version'].to_f >= 5.0
+  default['nodejs']['install_method'] = 'binary'
+  default['nodejs']['version'] = '8.7.0'
   default['nodejs']['binary']['checksum']['linux_x64'] = nil
 end

--- a/attributes/sdk.rb
+++ b/attributes/sdk.rb
@@ -138,15 +138,14 @@ default['cdap']['sdk']['init_cmd'] =
     "#{node['cdap']['sdk']['install_path']}/#{node['cdap']['sdk']['product_name']}/bin/cdap sandbox"
   end
 default['cdap']['sdk']['init_actions'] = [:enable, :start]
-# Get proper Node.js version on SDK 4.x
-if node['cdap']['version'].to_f >= 4.0 && node['cdap']['version'].to_f < 5.0
-  default['nodejs']['install_method'] = 'binary'
-  default['nodejs']['version'] = '4.5.0'
-  default['nodejs']['binary']['checksum']['linux_x64'] = nil
-end
-# Get proper Node.js version on SDK 5.0+
-if node['cdap']['version'].to_f >= 5.0
+
+# Get proper Node.js version on SDK
+if node['cdap']['version'].to_i >= 5
   default['nodejs']['install_method'] = 'binary'
   default['nodejs']['version'] = '8.7.0'
+  default['nodejs']['binary']['checksum']['linux_x64'] = nil
+elsif node['cdap']['version'].to_i >= 4
+  default['nodejs']['install_method'] = 'binary'
+  default['nodejs']['version'] = '4.5.0'
   default['nodejs']['binary']['checksum']['linux_x64'] = nil
 end


### PR DESCRIPTION
Update the default version of NodeJS to 8.7 for CDAP 5.0+. This is a prerequisite for https://issues.cask.co/browse/CDAP-14137