### PR TITLE
use Java 8 by default

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -57,4 +57,4 @@ suites:
       - recipe[cdap::sdk]
     attributes:
       java:
-        jdk_version: '7' 
+        jdk_version: '8'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-* Java JDK 7+ with JCE
+* Java JDK 8+ with JCE
 * Hadoop 2.0+ HDFS, YARN, ZooKeeper, Hive, and HBase
 
 ## Usage

--- a/attributes/java.rb
+++ b/attributes/java.rb
@@ -18,4 +18,4 @@
 #
 
 default['java']['install_flavor'] = 'openjdk'
-default['java']['jdk_version'] = '7'
+default['java']['jdk_version'] = '8'


### PR DESCRIPTION
With 5.1 CDAP release, we need to update the JDK version to 8
* update default attribute
* update test-kitchen attribute
* update README