### PR TITLE
Version bump for 3.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 cdap CHANGELOG
 ==============
 
+v3.6.0 (Oct 17, 2018)
+---------------------
+- update nodeJS default version for CDAP 5.0 ( Issue: #281 )
+- Support CDAP 5.1.0 ( Issue #282 )
+- Use Java 8 by default ( Issue #283 )
+
 v3.5.0 (Aug 3, 2018)
 --------------------
 - Set only JDK-version appropriate JVM options ( Issue: #278 )

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
   "recipes": {
 
   },
-  "version": "3.5.0",
+  "version": "3.6.0",
   "source_url": "https://github.com/caskdata/cdap_cookbook",
   "issues_url": "https://issues.cask.co/browse/COOK/component/10603",
   "privacy": false,

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache-2.0'
 description      'Installs/Configures Cask Data Application Platform (CDAP)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.5.0'
+version          '3.6.0'
 
 %w(ambari ark apt java nodejs ntp yum).each do |cb|
   depends cb

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -15,7 +15,7 @@ end
 
 [
   'ps auxww | grep -i cdap',
-  '/opt/cdap/sandbox/bin/cdap cli list namespaces | grep "Default Namespace"',
+  '/opt/cdap/sandbox/bin/cdap cli list namespaces | grep "default"',
 ].each do |cmd|
   describe command(cmd) do
     its('exit_status') { should eq 0 }


### PR DESCRIPTION
includes:
- update nodeJS default version for CDAP 5.0 ( Issue: #281 )
- Support CDAP 5.1.0 ( Issue #282 )
- Use Java 8 by default ( Issue #283 )